### PR TITLE
fix: update llm template config default to OpenAI standard

### DIFF
--- a/backend/conf/model/template/model_template_basic.yaml
+++ b/backend/conf/model/template/model_template_basic.yaml
@@ -164,7 +164,7 @@ meta:
             - bye
         enable_thinking: false
         openai:
-            by_azure: true
+            by_azure: false
             api_version: "2024-10-21"
             response_format:
                 type: text

--- a/backend/conf/model/template/model_template_openai.yaml
+++ b/backend/conf/model/template/model_template_openai.yaml
@@ -157,7 +157,7 @@ meta:
         top_k: 0
         stop: []
         openai:
-            by_azure: true
+            by_azure: false
             api_version: ""
             response_format:
                 type: text


### PR DESCRIPTION
#### What type of PR is this?
This PR changes the default value of by_azure from true to false to ensure compatibility with standard OpenAI API endpoints. When by_azure is enabled, the client automatically appends /openai/deployments/{model} to the request URL, which causes issues when using standard OpenAI endpoints (e.g., api.openai.com/v1/chat/completions).

#### (Optional) Translate the PR title into Chinese.
此 PR 将 by_azure 的默认值从 true 改为 false，以确保与标准 OpenAI API 端点兼容。启用 by_azure 时，客户端会自动在请求 URL 后添加 /openai/deployments/{model}，导致标准 OpenAI 接口（如 api.openai.com/v1/chat/completions）无法正常使用。

