### PR TITLE
Using text as the underlying type of string in a data table

### DIFF
--- a/backend/domain/memory/database/internal/convertor/types.go
+++ b/backend/domain/memory/database/internal/convertor/types.go
@@ -33,7 +33,7 @@ const (
 func SwitchToDataType(itemType table.FieldItemType) entity.DataType {
 	switch itemType {
 	case table.FieldItemType_Text:
-		return entity.TypeVarchar
+		return entity.TypeText
 	case table.FieldItemType_Number:
 		return entity.TypeBigInt
 	case table.FieldItemType_Date:

--- a/backend/infra/impl/rdb/mysql.go
+++ b/backend/infra/impl/rdb/mysql.go
@@ -64,6 +64,8 @@ func (m *mysqlService) CreateTable(ctx context.Context, req *rdb.CreateTableRequ
 		if col.DefaultValue != nil {
 			if col.DataType == entity2.TypeTimestamp {
 				colDef += fmt.Sprintf(" DEFAULT %s", *col.DefaultValue)
+			} else if col.DataType == entity2.TypeText {
+				// do nothing
 			} else {
 				colDef += fmt.Sprintf(" DEFAULT '%s'", *col.DefaultValue)
 			}


### PR DESCRIPTION
exist https://github.com/coze-dev/coze-studio/issues/95 In this issue, we found that when users use data tables, the string type corresponds to the underlying MySQL table type varchar255, and the input content is easily too long. Therefore, we will default the underlying type to text