### PR TITLE
docs: update CONTRIBUTING.md to reflect main branch usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 3. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the coze-dev {project_name} repo.
 4. In your forked repository, make your changes in a new git branch:
     ```
-    git checkout -b my-fix-branch develop
+    git checkout -b my-fix-branch main
     ```
 5. Create your patch, including appropriate test cases.
 6. Follow our [Style Guides](#code-style-guides).
@@ -38,7 +38,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     ```
     git push origin my-fix-branch
     ```
-9. In GitHub, send a pull request to `{project_name}:develop`
+9. In GitHub, send a pull request to `{project_name}:main`
 
 ## Contribution Prerequisites
 - Our development environment keeps up with [Go Official](https://golang.org/project/).


### PR DESCRIPTION
---

### 📝 PR Description

The repository no longer has a `develop` branch.  
This PR updates the `CONTRIBUTING.md` instructions to reference the `main` branch instead, to avoid confusion for new contributors.


#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

- [x] **docs**: Documentation only changes

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Add documentation if the current PR requires user awareness at the usage level.


#### (Optional) Translate the PR title into Chinese.

**文档**：更新 CONTRIBUTING.md 说明，改为使用 main 分支

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
This documentation fix helps contributors follow the latest default branch (`main`) instead of the outdated `develop` branch.

**zh：**  
本 PR 修复了 CONTRIBUTING.md 中使用 `develop` 分支的表述，更新为当前主分支 `main`，以免新贡献者困惑。



#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

_None_ 
