### PR TITLE
feat: add --es-address parameter to setup_es_index with .env support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,8 @@ atlas-hash:
 
 setup_es_index:
 	@echo "Setting up Elasticsearch index..."
-	@bash $(ES_SETUP_SCRIPT)  --index-dir $(ES_INDEX_SCHEMA) --docker-host false
+	@. $(ENV_FILE); \
+	bash $(ES_SETUP_SCRIPT) --index-dir $(ES_INDEX_SCHEMA) --docker-host false --es-address "$$ES_ADDR"
 
 help:
 	@echo "Usage: make [target]"


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

**fix**: A bug fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Add documentation if the current PR requires user awareness at the usage level.

**PR Title**: `fix: resolve setup_es_index failure by loading ES_ADDR from .env file`

#### (Optional) Translate the PR title into Chinese.

**中文标题**: `fix: 通过从 .env 文件加载 ES_ADDR 解决 setup_es_index 执行失败问题`

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->

**en**: 
**Problem**: When executing `make setup_es_index` during local development, the command fails because the Makefile doesn't load environment variables from `.env` file using `. $(ENV_FILE)`, causing `ES_ADDR` to be undefined when `setup_es.sh` script tries to connect to Elasticsearch.

**Solution**: 
- Modified the `setup_es_index` target in Makefile to use `. $(ENV_FILE)` for loading environment variables from `.env` file
- Added `--es-address` parameter to explicitly pass `ES_ADDR` from environment to `setup_es.sh`
- Ensures the Elasticsearch address is properly configured from `.env` file for local development
- The `setup_es.sh` script already supports both `--es-address` parameter and `ES_ADDR` environment variable

**zh**: 
**问题**: 在本地开发环境中执行 `make setup_es_index` 命令时，由于 Makefile 没有使用 `. $(ENV_FILE)` 从 `.env` 文件加载环境变量，导致 `setup_es.sh` 脚本在尝试连接 Elasticsearch 时 `ES_ADDR` 变量未定义。

**解决方案**: 
- 修改 Makefile 中的 `setup_es_index` 目标，使用 `. $(ENV_FILE)` 从 `.env` 文件加载环境变量
- 添加 `--es-address` 参数，显式地将环境中的 `ES_ADDR` 传递给 `setup_es.sh`
- 确保 Elasticsearch 地址从 `.env` 文件正确配置用于本地开发
- `setup_es.sh` 脚本本身已支持 `--es-address` 参数和 `ES_ADDR` 环境变量

| Before | After |
|--------|-------|
|<img width="1600" height="567" alt="image" src="https://github.com/user-attachments/assets/73459a37-9354-4675-979f-61c60db51bc0" /><img width="439" height="719" alt="image" src="https://github.com/user-attachments/assets/266396da-d3a8-49eb-85ad-107227fad678" /><img width="829" height="320" alt="image" src="https://github.com/user-attachments/assets/a76e9f1c-8620-4dc1-9c9b-fb95dc5979aa" /> | <img width="535" height="407" alt="image" src="https://github.com/user-attachments/assets/310f03cc-45c6-467b-889b-78dcf886a906" />|

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/coze-dev/coze-studio/issues/178

