### PR TITLE
fix: Optimize knowledge domain error codes to expose previous errors during retries

### DIFF
--- a/backend/application/knowledge/knowledge.go
+++ b/backend/application/knowledge/knowledge.go
@@ -438,7 +438,7 @@ func (k *KnowledgeApplicationService) GetDocumentProgress(ctx context.Context, r
 			DocumentID:     domainResp.ProgressList[i].ID,
 			Progress:       int32(domainResp.ProgressList[i].Progress),
 			Status:         convertDocumentStatus2Model(domainResp.ProgressList[i].Status),
-			StatusDescript: ptr.Of(convertDocumentStatus2Model(domainResp.ProgressList[i].Status).String()),
+			StatusDescript: &domainResp.ProgressList[i].StatusMsg,
 			DocumentName:   domainResp.ProgressList[i].Name,
 			RemainingTime:  &domainResp.ProgressList[i].RemainingSec,
 			Size:           &domainResp.ProgressList[i].Size,

--- a/backend/domain/knowledge/internal/dal/dao/knowledge_document_slice.go
+++ b/backend/domain/knowledge/internal/dal/dao/knowledge_document_slice.go
@@ -58,9 +58,7 @@ func (dao *KnowledgeDocumentSliceDAO) BatchCreate(ctx context.Context, slices []
 func (dao *KnowledgeDocumentSliceDAO) BatchSetStatus(ctx context.Context, ids []int64, status int32, reason string) error {
 	s := dao.Query.KnowledgeDocumentSlice
 	updates := map[string]any{s.Status.ColumnName().String(): status}
-	if reason != "" {
-		updates[s.FailReason.ColumnName().String()] = reason
-	}
+	updates[s.FailReason.ColumnName().String()] = reason
 	updates[s.UpdatedAt.ColumnName().String()] = time.Now().UnixMilli()
 	_, err := s.WithContext(ctx).Where(s.ID.In(ids...)).Updates(updates)
 	return err


### PR DESCRIPTION
https://github.com/coze-dev/coze-studio/issues/55，https://github.com/coze-dev/coze-studio/issues/49 ...Fix the problem of progress being 0 mentioned in the above issues. The cause of the problem may be model configuration problems, OCR configuration problems, etc. Because the document import has a retry logic, the progress is always displayed as 0. Through this commit, we write the error cause into the knowledge_document table and expose the error to the front. At the same time, the underlying retry logic will not stop, and try to import as much as possible.