### PR TITLE
fix: config of middleware service name

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -13,7 +13,7 @@ export MYSQL_ROOT_PASSWORD=root
 export MYSQL_DATABASE=opencoze
 export MYSQL_USER=coze
 export MYSQL_PASSWORD=coze123
-export MYSQL_HOST=coze-mysql
+export MYSQL_HOST=mysql
 export MYSQL_PORT=3306
 export MYSQL_DSN="${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DATABASE}?charset=utf8mb4&parseTime=True"
 export ATLAS_URL="mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?charset=utf8mb4&parseTime=True"
@@ -22,7 +22,7 @@ export ATLAS_URL="mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_
 export REDIS_AOF_ENABLED=no
 export REDIS_IO_THREADS=4
 export ALLOW_EMPTY_PASSWORD=yes
-export REDIS_ADDR="coze-redis:6379"
+export REDIS_ADDR="redis:6379"
 export REDIS_PASSWORD=""
 
 # This Upload component used in Agent / workflow File/Image With LLM  , support the component of imagex / storage
@@ -47,7 +47,7 @@ export MINIO_ROOT_PASSWORD=minioadmin123
 export MINIO_DEFAULT_BUCKETS=milvus
 export MINIO_AK=$MINIO_ROOT_USER
 export MINIO_SK=$MINIO_ROOT_PASSWORD
-export MINIO_ENDPOINT="coze-minio:9000"
+export MINIO_ENDPOINT="minio:9000"
 export MINIO_API_HOST="http://${MINIO_ENDPOINT}"
 
 # TOS
@@ -65,14 +65,14 @@ export S3_BUCKET_ENDPOINT=
 export S3_REGION=
 
 # Elasticsearch
-export ES_ADDR="http://coze-elasticsearch:9200"
+export ES_ADDR="http://elasticsearch:9200"
 export ES_VERSION="v8"
 export ES_USERNAME=""
 export ES_PASSWORD=""
 
 
 export COZE_MQ_TYPE="nsq" # nsq / kafka / rmq
-export MQ_NAME_SERVER="coze-nsqd:4150"
+export MQ_NAME_SERVER="nsqd:4150"
 # RocketMQ
 export RMQ_ACCESS_KEY=""
 export RMQ_SECRET_KEY=""
@@ -82,7 +82,7 @@ export RMQ_SECRET_KEY=""
 # If you want to use vikingdb, you need to set up the vikingdb configuration.
 export VECTOR_STORE_TYPE="milvus"
 # milvus vector store
-export MILVUS_ADDR="coze-milvus:19530"
+export MILVUS_ADDR="milvus:19530"
 # vikingdb vector store for Volcengine
 export VIKING_DB_HOST=""
 export VIKING_DB_REGION=""

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -246,8 +246,8 @@ services:
     security_opt:
       - seccomp:unconfined
     environment:
-      ETCD_ENDPOINTS: coze-etcd:2379
-      MINIO_ADDRESS: coze-minio:9000
+      ETCD_ENDPOINTS: etcd:2379
+      MINIO_ADDRESS: minio:9000
       MINIO_BUCKET_NAME: ${MINIO_BUCKET:-milvus}
       MINIO_ACCESS_KEY_ID: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin123}
@@ -291,7 +291,7 @@ services:
   nsqd:
     image: nsqio/nsq:v1.2.1
     container_name: coze-nsqd
-    command: /nsqd --lookupd-tcp-address=coze-nsqlookupd:4160 --broadcast-address=coze-nsqd
+    command: /nsqd --lookupd-tcp-address=nsqlookupd:4160 --broadcast-address=nsqd
     restart: always
     ports:
       - '4150'
@@ -311,7 +311,7 @@ services:
   nsqadmin:
     image: nsqio/nsq:v1.2.1
     container_name: coze-nsqadmin
-    command: /nsqadmin --lookupd-http-address=coze-nsqlookupd:4161
+    command: /nsqadmin --lookupd-http-address=nsqlookupd:4161
     restart: always
     ports:
       - '4171'


### PR DESCRIPTION
In Docker Compose networks, communication between services uses service names (service name), not container names (container_name). Service names are the names defined under services: in the docker-compose.yml file, while container names are only used for container identification.