### PR TITLE
fix: Fix pre-push-hook.sh to prevent fork users from syncing upstream…

### DIFF
--- a/frontend/scripts/pre-push-hook.sh
+++ b/frontend/scripts/pre-push-hook.sh
@@ -25,13 +25,20 @@ CURRENT_USER=$(git config user.email)
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 CURRENT_ORIGIN_BRANCH=$(git rev-parse --abbrev-ref @{u})
 
+# Get current origin URL
+CURRENT_ORIGIN_URL=$(git remote get-url origin)
+
 # if [[ -n "$CURRENT_ORIGIN_BRANCH" ]]; then
 #   block_unresolved_conflict "$CURRENT_BRANCH..$CURRENT_ORIGIN_BRANCH"
 # fi
 
-if [ "$CURRENT_BRANCH" = "main" ] && [ "$CURRENT_USER" != "ci_flow@bytedance.com" ]; then
-  echo "${RED}Do not push to main branch manually!!!${NC}"
-  exit 1
+# Check if current origin contains coze-dev/coze-studio
+if [[ "$CURRENT_ORIGIN_URL" == *"coze-dev/coze-studio"* ]]; then
+  # Block push to main branch for coze-dev/coze-studio repository
+  if [ "$CURRENT_BRANCH" = "main" ] && [ "$CURRENT_USER" != "ci_flow@bytedance.com" ]; then
+    echo "${RED}Do not push to main branch manually!!!${NC}"
+    exit 1
+  fi
 fi
 
 if git status --porcelain | grep -q "pnpm-lock.yaml"; then


### PR DESCRIPTION
当fork 用户同步main 分枝, 并推送时候, 出现如下错误.

![image](https://github.com/user-attachments/assets/0ccd5881-0404-456c-9870-d7b53a371736)

增加pre-push-hook.sh 判断origin url

已经测试如下ORIGIN_URL (主动赋值 CURRENT_ORIGIN_URL 做不允许测试)

-  CURRENT_ORIGIN_URL="https://github.com/coze-dev/coze-studio.git"
- CURRENT_ORIGIN_URL="git@github.com:coze-dev/coze-studio.git"   
-  CURRENT_ORIGIN_URL="https://github.com/coze-dev/coze-studio"   
-  CURRENT_ORIGIN_URL="git@github.com:coze-dev/coze-studio"      