### PR TITLE
fix(api): support assistant role in additional_messages #41

### DIFF
--- a/backend/application/conversation/openapi_agent_run.go
+++ b/backend/application/conversation/openapi_agent_run.go
@@ -204,7 +204,7 @@ func (a *OpenapiAgentRunApplication) buildMultiContent(ctx context.Context, ar *
 		if item == nil {
 			continue
 		}
-		if item.Role != string(schema.User) {
+		if item.Role != string(schema.User) && item.Role != string(schema.Assistant) {
 			return nil, contentType, errors.New("role not match")
 		}
 		if item.ContentType == run.ContentTypeText {


### PR DESCRIPTION
## 🐛 Problem Description

The `/v3/chat` API's `additional_messages` field rejects messages with `role: "assistant"`, returning error code 103100001 "role not match". However, according to the [official Coze documentation](https://www.coze.cn/open/docs/developer_guides/chat_v3), assistant role should be supported.

## 🔧 Solution

Modified role validation logic in `backend/application/conversation/openapi_agent_run.go:207`:

**Before**:
\`\`\`go
if item.Role \!= string(schema.User) {
    return nil, contentType, errors.New("role not match")
}
\`\`\`

**After**:
\`\`\`go
if item.Role \!= string(schema.User) && item.Role \!= string(schema.Assistant) {
    return nil, contentType, errors.New("role not match")
}
\`\`\`

## ✅ Testing

- Verified API accepts both \`user\` and \`assistant\` roles
- Confirmed backward compatibility maintained
- No more "role not match" errors with assistant messages

## 📈 Impact

- ✅ Fixes API compliance with official documentation
- ✅ Enables proper conversation context with assistant history
- ✅ Backward compatible - existing \`user\` role behavior unchanged
- ✅ Minimal change - single line modification, low risk

Closes #41