### PR TITLE
fix: app var store can be resumed

### DIFF
--- a/backend/domain/workflow/crossdomain/plugin/pluginmock/plugin_mock.go
+++ b/backend/domain/workflow/crossdomain/plugin/pluginmock/plugin_mock.go
@@ -29,8 +29,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	plugin "github.com/coze-dev/coze-studio/backend/domain/workflow/crossdomain/plugin"
 	schema "github.com/cloudwego/eino/schema"
+	plugin "github.com/coze-dev/coze-studio/backend/domain/workflow/crossdomain/plugin"
+	vo "github.com/coze-dev/coze-studio/backend/domain/workflow/entity/vo"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -101,6 +102,20 @@ func (m *MockService) GetPluginToolsInfo(ctx context.Context, req *plugin.ToolsI
 func (mr *MockServiceMockRecorder) GetPluginToolsInfo(ctx, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPluginToolsInfo", reflect.TypeOf((*MockService)(nil).GetPluginToolsInfo), ctx, req)
+}
+
+// UnwrapArrayItemFieldsInVariable mocks base method.
+func (m *MockService) UnwrapArrayItemFieldsInVariable(v *vo.Variable) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnwrapArrayItemFieldsInVariable", v)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnwrapArrayItemFieldsInVariable indicates an expected call of UnwrapArrayItemFieldsInVariable.
+func (mr *MockServiceMockRecorder) UnwrapArrayItemFieldsInVariable(v any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnwrapArrayItemFieldsInVariable", reflect.TypeOf((*MockService)(nil).UnwrapArrayItemFieldsInVariable), v)
 }
 
 // MockInvokableTool is a mock of InvokableTool interface.

--- a/backend/domain/workflow/internal/canvas/adaptor/canvas_test.go
+++ b/backend/domain/workflow/internal/canvas/adaptor/canvas_test.go
@@ -655,11 +655,10 @@ func TestKnowledgeNodes(t *testing.T) {
 		mockKnowledgeOperator.EXPECT().Retrieve(gomock.Any(), gomock.Any()).Return(rResponse, nil)
 		mockGlobalAppVarStore := mockvar.NewMockStore(ctrl)
 		mockGlobalAppVarStore.EXPECT().Get(gomock.Any(), gomock.Any()).Return("v1", nil).AnyTimes()
-		mockGlobalAppVarStore.EXPECT().Set(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-		variable.SetVariableHandler(&variable.Handler{
-			AppVarStore: mockGlobalAppVarStore,
-		})
+		variable.SetVariableHandler(&variable.Handler{AppVarStore: mockGlobalAppVarStore})
+
+		mockey.Mock(execute.GetAppVarStore).Return(&execute.AppVariables{Vars: map[string]any{}}).Build()
 
 		ctx := t.Context()
 		ctx = ctxcache.Init(ctx)


### PR DESCRIPTION
previous if a workflow interrupts, then attempts to read/write a app variable, the workflow will panic. 

This fixes this by exporting the map within app var store so that it can be checkpointed.

Also moved the AppVarStore from state to ExecuteContext so after interrupt/resume, the parent/child workflow can still share the same AppVarStore

#### (Optional) Which issue(s) this PR fixes:
Fixes https://github.com/coze-dev/coze-studio/issues/539
