### PR TITLE
fix: When agents use data tables, different users influence each other

### DIFF
--- a/backend/domain/memory/database/service/database_impl.go
+++ b/backend/domain/memory/database/service/database_impl.go
@@ -1074,7 +1074,16 @@ func (d databaseService) executeCustomSQL(ctx context.Context, req *ExecuteSQLRe
 	if err != nil {
 		return nil, fmt.Errorf("parse sql failed: %v", err)
 	}
-
+	// add rw mode
+	if tableInfo.RwMode == table.BotTableRWMode_LimitedReadWrite && len(req.UserID) != 0 {
+		switch operation {
+		case sqlparsercontract.OperationTypeSelect, sqlparsercontract.OperationTypeUpdate, sqlparsercontract.OperationTypeDelete:
+			parsedSQL, err = sqlparser.NewSQLParser().AppendSQLFilter(parsedSQL, sqlparsercontract.SQLFilterOpAnd, fmt.Sprintf("%s = '%s'", database.DefaultUidColName, req.UserID))
+			if err != nil {
+				return nil, fmt.Errorf("append sql filter failed: %v", err)
+			}
+		}
+	}
 	insertResult := make([]map[string]interface{}, 0)
 	if operation == sqlparsercontract.OperationTypeInsert {
 		cid := consts.CozeConnectorID

--- a/backend/infra/contract/sqlparser/sql_parser.go
+++ b/backend/infra/contract/sqlparser/sql_parser.go
@@ -48,6 +48,13 @@ const (
 	OperationTypeUnknown  OperationType = "UNKNOWN"
 )
 
+type SQLFilterOp string
+
+const (
+	SQLFilterOpAnd SQLFilterOp = "AND"
+	SQLFilterOpOr  SQLFilterOp = "OR"
+)
+
 // SQLParser defines the interface for parsing and modifying SQL statements
 type SQLParser interface {
 	// ParseAndModifySQL parses SQL and replaces table/column names according to the provided message
@@ -64,4 +71,7 @@ type SQLParser interface {
 
 	// GetInsertDataNums extracts the number of rows to be inserted from a SQL statement. Only supports single-table insert.
 	GetInsertDataNums(sql string) (int, error)
+
+	// AppendSQLFilter appends a filter condition to the SQL statement.
+	AppendSQLFilter(sql string, op SQLFilterOp, filter string) (string, error)
 }


### PR DESCRIPTION

#### (Optional) Translate the PR title into Chinese.
修复agent使用数据库时，不同用户的数据相互影响的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:When users execute custom SQL, add where UID=? The condition makes custom SQL only affect the user's own data
zh(optional): 在用户执行自定义sql时，增加where uid = ?的条件使自定义sql只能影响用户自己的数据