### PR TITLE
fix: Fix bug in initializing database tool for agent

### DIFF
--- a/backend/domain/agent/singleagent/internal/agentflow/node_tool_database.go
+++ b/backend/domain/agent/singleagent/internal/agentflow/node_tool_database.go
@@ -112,22 +112,21 @@ func newDatabaseTools(ctx context.Context, conf *databaseConfig) ([]tool.Invokab
 
 	dbInfos := conf.databaseConf
 
-	d := &databaseTool{
-		spaceID:       conf.spaceID,
-		connectorUID:  conf.userID,
-		agentIdentity: conf.agentIdentity,
-	}
-
 	tools := make([]tool.InvokableTool, 0, len(dbInfos))
 	for _, dbInfo := range dbInfos {
 		tID, err := strconv.ParseInt(dbInfo.GetTableId(), 10, 64)
 		if err != nil {
 			return nil, err
 		}
+		d := &databaseTool{
+			spaceID:        conf.spaceID,
+			connectorUID:   conf.userID,
+			agentIdentity:  conf.agentIdentity,
+			promptDisabled: dbInfo.GetPromptDisabled(),
+			name:           dbInfo.GetTableName(),
+			databaseID:     tID,
+		}
 
-		d.databaseID = tID
-		d.promptDisabled = dbInfo.GetPromptDisabled()
-		d.name = dbInfo.GetTableName()
 		dbTool, err := utils.InferTool(dbInfo.GetTableName(), buildDatabaseToolDescription(dbInfo), d.Invoke)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
fix: Fix bug in initializing database tool for agent

#### (Optional) Translate the PR title into Chinese.
修复agent初始化database tool的bug

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:When initializing the database tool, all database tools point to the same instance, which is a logical problem in the code
zh(optional): database tool初始化时，所有database tool指向同一个实例，代码逻辑问题；


#### (Optional) Which issue(s) this PR fixes:
Fixes #<557>https://github.com/coze-dev/coze-studio/issues/557
