### PR TITLE
fix: do not throw error when encountering unknown param for LLM

### DIFF
--- a/backend/domain/workflow/internal/nodes/llm/llm.go
+++ b/backend/domain/workflow/internal/nodes/llm/llm.go
@@ -328,7 +328,8 @@ func llmParamsToLLMParam(params vo.LLMParam) (*crossmodel.LLMParams, error) {
 			}
 			p.TopP = &floatVar
 		default:
-			return nil, fmt.Errorf("invalid LLMParam name: %s", param.Name)
+			logs.Warnf("encountered unknown param when converting LLM Params, name= %s, "+
+				"value= %v", param.Name, param.Input.Value.Content)
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

when encountering unknown param of LLM config, instead of throwing error, print a warning log