### PR TITLE
fix: Elasticsearch OpIn query append to Must instead of MustNot

### DIFF
--- a/backend/infra/impl/document/searchstore/elasticsearch/elasticsearch_searchstore.go
+++ b/backend/infra/impl/document/searchstore/elasticsearch/elasticsearch_searchstore.go
@@ -185,7 +185,7 @@ func (e *esSearchStore) travDSL(query *es.Query, dsl *searchstore.DSL) error {
 		query.Bool.Must = append(query.Bool.Must, es.NewMatchQuery(dsl.Field, s))
 
 	case searchstore.OpIn:
-		query.Bool.Must = append(query.Bool.MustNot,
+		query.Bool.Must = append(query.Bool.Must,
 			es.NewInQuery(dsl.Field, stringifyValue(dsl.Value)))
 
 	case searchstore.OpAnd, searchstore.OpOr:


### PR DESCRIPTION
#### What type of PR is this?
fix: A bug fix

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.
修复(elasticsearch): OpIn 查询操作错误地添加到 MustNot 而不是 Must

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:
**Problem**: `OpIn` operation was incorrectly appending to `MustNot`, causing:
- Query logic inversion (exclude instead of include)
- Text search conditions to be lost
- Search queries to only contain document_id filtering

**Fix**: Changed append target from `MustNot` to `Must` to preserve search logic and text content search.

**Impact**: Restores full search functionality including text content search with document filtering.

**Root Cause**: In `internal/searchstore/elasticsearch/elasticsearch_searchstore.go`, the `OpIn` case was appending queries to the wrong boolean query section, resulting in inverted search logic and missing text search conditions.

**Testing**: Verified that search queries now properly include both document filtering and text content search, restoring the expected search behavior.

zh(optional): 
**问题**: `OpIn` 操作错误地添加到 `MustNot` 而不是 `Must`，导致：
- 查询逻辑反转（排除而不是包含）
- 文本搜索条件丢失
- 搜索查询只包含文档ID过滤

**修复**: 将追加目标从 `MustNot` 改为 `Must`，以保持搜索逻辑和文本内容搜索。

**影响**: 恢复完整的搜索功能，包括带文档过滤的文本内容搜索。

#### (Optional) Which issue(s) this PR fixes:
Fixes search functionality for knowledge document queries using IN conditions with text content search.