### PR TITLE
fix(knowledge): Fix the issue of ineffective pagination parameters in the image-based knowledge base

### DIFF
--- a/backend/domain/knowledge/entity/slice.go
+++ b/backend/domain/knowledge/entity/slice.go
@@ -27,8 +27,15 @@ type WhereSliceOpt struct {
 	DocumentID  int64
 	DocumentIDs []int64
 	Keyword     *string
-	Sequence    int64
 	PageSize    int64
 	Offset      int64
 	NotEmpty    *bool
+}
+
+type WherePhotoSliceOpt struct {
+	KnowledgeID int64
+	DocumentIDs []int64
+	Limit       *int
+	Offset      *int
+	HasCaption  *bool
 }

--- a/backend/domain/knowledge/internal/dal/dao/knowledge_document_slice.go
+++ b/backend/domain/knowledge/internal/dal/dao/knowledge_document_slice.go
@@ -236,8 +236,11 @@ func (dao *KnowledgeDocumentSliceDAO) FindSliceByCondition(ctx context.Context, 
 
 	if opts.PageSize != 0 {
 		do = do.Limit(int(opts.PageSize))
-		do = do.Offset(int(opts.Sequence)).Order(s.Sequence.Asc())
 	}
+	if opts.Offset != 0 {
+		do = do.Offset(int(opts.Offset))
+	}
+	do = do.Order(s.Sequence.Asc())
 	if opts.NotEmpty != nil {
 		if ptr.From(opts.NotEmpty) {
 			do = do.Where(s.Content.Neq(""))
@@ -318,4 +321,45 @@ func (dao *KnowledgeDocumentSliceDAO) GetLastSequence(ctx context.Context, docum
 			errorx.KVf("reason", "[GetLastSequence] resp is nil, document_id=%v", documentID))
 	}
 	return resp.Sequence, nil
+}
+
+func (dao *KnowledgeDocumentSliceDAO) ListPhotoSlice(ctx context.Context, opts *entity.WherePhotoSliceOpt) ([]*model.KnowledgeDocumentSlice, int64, error) {
+	s := dao.Query.KnowledgeDocumentSlice
+	do := s.WithContext(ctx)
+	if opts.KnowledgeID != 0 {
+		do = do.Where(s.KnowledgeID.Eq(opts.KnowledgeID))
+	}
+	if len(opts.DocumentIDs) != 0 {
+		do = do.Where(s.DocumentID.In(opts.DocumentIDs...))
+	}
+	if ptr.From(opts.Limit) != 0 {
+		do = do.Limit(int(ptr.From(opts.Limit)))
+	}
+	if ptr.From(opts.Offset) != 0 {
+		do = do.Offset(int(ptr.From(opts.Offset)))
+	}
+	if opts.HasCaption != nil {
+		if ptr.From(opts.HasCaption) {
+			do = do.Where(s.Content.Neq(""))
+		} else {
+			do = do.Where(s.Content.Eq(""))
+		}
+	}
+	do = do.Order(s.UpdatedAt.Desc())
+	pos, err := do.Find()
+	if err != nil {
+		return nil, 0, err
+	}
+	total, err := do.Limit(-1).Offset(-1).Count()
+	if err != nil {
+		return nil, 0, err
+	}
+	return pos, total, nil
+}
+
+func (dao *KnowledgeDocumentSliceDAO) BatchCreateWithTX(ctx context.Context, tx *gorm.DB, slices []*model.KnowledgeDocumentSlice) error {
+	if len(slices) == 0 {
+		return nil
+	}
+	return tx.WithContext(ctx).Debug().Model(&model.KnowledgeDocumentSlice{}).CreateInBatches(slices, 100).Error
 }

--- a/backend/domain/knowledge/repository/repository.go
+++ b/backend/domain/knowledge/repository/repository.go
@@ -84,12 +84,12 @@ type KnowledgeDocumentSliceRepo interface {
 	Create(ctx context.Context, slice *model.KnowledgeDocumentSlice) error
 	Update(ctx context.Context, slice *model.KnowledgeDocumentSlice) error
 	Delete(ctx context.Context, slice *model.KnowledgeDocumentSlice) error
-
+	BatchCreateWithTX(ctx context.Context, tx *gorm.DB, slices []*model.KnowledgeDocumentSlice) error
 	BatchCreate(ctx context.Context, slices []*model.KnowledgeDocumentSlice) error
 	BatchSetStatus(ctx context.Context, ids []int64, status int32, reason string) error
 	DeleteByDocument(ctx context.Context, documentID int64) error
 	MGetSlices(ctx context.Context, sliceIDs []int64) ([]*model.KnowledgeDocumentSlice, error)
-
+	ListPhotoSlice(ctx context.Context, opts *entity.WherePhotoSliceOpt) ([]*model.KnowledgeDocumentSlice, int64, error)
 	FindSliceByCondition(ctx context.Context, opts *entity.WhereSliceOpt) (
 		[]*model.KnowledgeDocumentSlice, int64, error)
 	GetDocumentSliceIDs(ctx context.Context, docIDs []int64) (sliceIDs []int64, err error)

--- a/backend/domain/knowledge/service/knowledge.go
+++ b/backend/domain/knowledge/service/knowledge.go
@@ -876,9 +876,8 @@ func (k *knowledgeSVC) ListSlice(ctx context.Context, request *ListSliceRequest)
 		KnowledgeID: ptr.From(request.KnowledgeID),
 		DocumentID:  ptr.From(request.DocumentID),
 		Keyword:     request.Keyword,
-		Sequence:    request.Sequence,
+		Offset:      request.Sequence,
 		PageSize:    request.Limit,
-		Offset:      request.Offset,
 	})
 	if err != nil {
 		logs.CtxErrorf(ctx, "list slice failed, err: %v", err)
@@ -1375,12 +1374,12 @@ func (k *knowledgeSVC) ListPhotoSlice(ctx context.Context, request *ListPhotoSli
 	if request == nil {
 		return nil, errorx.New(errno.ErrKnowledgeInvalidParamCode, errorx.KV("msg", "request is empty"))
 	}
-	sliceArr, total, err := k.sliceRepo.FindSliceByCondition(ctx, &entity.WhereSliceOpt{
+	sliceArr, total, err := k.sliceRepo.ListPhotoSlice(ctx, &entity.WherePhotoSliceOpt{
 		KnowledgeID: request.KnowledgeID,
 		DocumentIDs: request.DocumentIDs,
-		Offset:      int64(ptr.From(request.Offset)),
-		PageSize:    int64(ptr.From(request.Limit)),
-		NotEmpty:    request.HasCaption,
+		Offset:      request.Offset,
+		Limit:       request.Limit,
+		HasCaption:  request.HasCaption,
 	})
 	if err != nil {
 		return nil, errorx.New(errno.ErrKnowledgeDBCode, errorx.KV("msg", err.Error()))


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.


#### (Optional) Translate the PR title into Chinese.
修复图片型知识库分页参数不生效的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:When paginating the image-based knowledge base, the offset parameter does not take effect. And the field values of 'order by' are all the same, causing MySQL to randomly query
zh(optional): 图片型知识库分页时，offset参数未生效。且order by的字段值全部相同，导致mysql随机查询


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
