### PR TITLE
fix(docker): add missing MINIO_BUCKET environment variable

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -46,6 +46,7 @@ export STORAGE_BUCKET="opencoze"
 # MiniIO
 export MINIO_ROOT_USER=minioadmin
 export MINIO_ROOT_PASSWORD=minioadmin123
+export MINIO_BUCKET=opencoze
 export MINIO_DEFAULT_BUCKETS=milvus
 export MINIO_AK=$MINIO_ROOT_USER
 export MINIO_SK=$MINIO_ROOT_PASSWORD

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -46,7 +46,6 @@ export STORAGE_BUCKET="opencoze"
 # MiniIO
 export MINIO_ROOT_USER=minioadmin
 export MINIO_ROOT_PASSWORD=minioadmin123
-export MINIO_BUCKET=opencoze
 export MINIO_DEFAULT_BUCKETS=milvus
 export MINIO_AK=$MINIO_ROOT_USER
 export MINIO_SK=$MINIO_ROOT_PASSWORD

--- a/docker/docker-compose-debug.yml
+++ b/docker/docker-compose-debug.yml
@@ -356,7 +356,7 @@ services:
     environment:
       ETCD_ENDPOINTS: coze-etcd:2379
       MINIO_ADDRESS: coze-minio:9000
-      MINIO_BUCKET_NAME: ${MINIO_BUCKET:-milvus}
+      MINIO_BUCKET_NAME: ${MINIO_DEFAULT_BUCKETS:-milvus}
       MINIO_ACCESS_KEY_ID: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin123}
       MINIO_USE_SSL: false

--- a/docker/docker-compose-debug.yml
+++ b/docker/docker-compose-debug.yml
@@ -285,7 +285,7 @@ services:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin123}
-      MINIO_DEFAULT_BUCKETS: ${MINIO_BUCKET:-opencoze},${MINIO_DEFAULT_BUCKETS:-milvus}
+      MINIO_DEFAULT_BUCKETS: ${STORAGE_BUCKET:-opencoze},${MINIO_DEFAULT_BUCKETS:-milvus}
     command: server /data --console-address ":9001"
     healthcheck:
       test:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -176,7 +176,7 @@ services:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin123}
-      MINIO_DEFAULT_BUCKETS: ${MINIO_BUCKET:-opencoze},${MINIO_DEFAULT_BUCKETS:-milvus}
+      MINIO_DEFAULT_BUCKETS: ${STORAGE_BUCKET:-opencoze},${MINIO_DEFAULT_BUCKETS:-milvus}
     entrypoint:
       - /bin/sh
       - -c

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -268,7 +268,7 @@ services:
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000
-      MINIO_BUCKET_NAME: ${MINIO_BUCKET:-milvus}
+      MINIO_BUCKET_NAME: ${MINIO_DEFAULT_BUCKETS:-milvus}
       MINIO_ACCESS_KEY_ID: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin123}
       MINIO_USE_SSL: false


### PR DESCRIPTION
#### What type of PR is this?
**fix** - 这是一个bug修复，解决了环境变量未定义的问题

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Add documentation if the current PR requires user awareness at the usage level.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
**en:**
This PR adds the missing `MINIO_BUCKET` environment variable to resolve undefined variable references in the docker-compose.yml configuration. The variable is used in two places:
1. `MINIO_DEFAULT_BUCKETS` configuration for MinIO service
2. `MINIO_BUCKET_NAME` configuration for Milvus service

Without this variable defined, the docker setup may encounter configuration issues or use fallback values that might not match the intended configuration.

**zh:**
此PR添加了缺失的 `MINIO_BUCKET` 环境变量，解决了docker-compose.yml配置中未定义变量引用的问题。该变量在两个地方被使用：
1. MinIO服务的 `MINIO_DEFAULT_BUCKETS` 配置
2. Milvus服务的 `MINIO_BUCKET_NAME` 配置

如果没有定义此变量，docker设置可能会遇到配置问题或使用可能与预期配置不匹配的默认值。

#### (Optional) Which issue(s) this PR fixes:
