### PR TITLE
fix: workflow tool in react agent resume once in one agent run

### DIFF
--- a/backend/domain/workflow/entity/interrupt_event.go
+++ b/backend/domain/workflow/entity/interrupt_event.go
@@ -35,6 +35,7 @@ type InterruptEvent struct {
 	NodeIcon      string             `json:"node_icon,omitempty"`
 	EventType     InterruptEventType `json:"event_type"`
 	NodePath      []string           `json:"node_path,omitempty"`
+	Popped        bool               `json:"popped,omitempty"`
 
 	// index within composite node -> interrupt info for that index
 	// TODO: separate the following fields with InterruptEvent
@@ -60,6 +61,7 @@ type ResumeRequest struct {
 	ExecuteID  int64
 	EventID    int64
 	ResumeData string
+	Resumed    bool
 }
 
 func (r *ResumeRequest) GetResumeID() string {

--- a/backend/domain/workflow/internal/execute/event_handle.go
+++ b/backend/domain/workflow/internal/execute/event_handle.go
@@ -283,7 +283,7 @@ func handleEvent(ctx context.Context, event *Event, repo workflow.Repository,
 			return noTerminate, fmt.Errorf("failed to update workflow execution to interrupted for execution id %d, current status is %v", exeID, currentStatus)
 		}
 
-		if event.RootCtx.ResumeEvent != nil {
+		if event.RootCtx.ResumeEvent != nil && !event.RootCtx.ResumeEvent.Popped {
 			needPop := false
 			for _, ie := range event.InterruptEvents {
 				if ie.NodeKey == event.RootCtx.ResumeEvent.NodeKey {

--- a/backend/domain/workflow/internal/nodes/llm/llm.go
+++ b/backend/domain/workflow/internal/nodes/llm/llm.go
@@ -971,6 +971,8 @@ func (l *LLM) prepare(ctx context.Context, _ map[string]any, opts ...nodes.NodeO
 					return ctx
 				}
 
+				c.RootCtx.ResumeEvent.Popped = true
+
 				return ctx
 			},
 		}).Handler()


### PR DESCRIPTION
#### What type of PR is this?

workflow tool within LLM Node's react agent or Agent's react agent, will only resume once during one react agent run, even if the ChatModel decided to call the tool multiple times