### PR TITLE
fix: python code execution misinterpreted warning logs as errors

### DIFF
--- a/backend/infra/impl/coderunner/direct/runner.go
+++ b/backend/infra/impl/coderunner/direct/runner.go
@@ -87,9 +87,6 @@ func (r *runner) pythonCmdRun(_ context.Context, code string, params map[string]
 	if err != nil {
 		return nil, fmt.Errorf("failed to run python script err: %s, std err: %s", err.Error(), stderr.String())
 	}
-	if stderr.String() != "" {
-		return nil, fmt.Errorf("failed to run python script err: %s", stderr.String())
-	}
 
 	ret := make(map[string]any)
 	err = sonic.Unmarshal(stdout.Bytes(), &ret)


### PR DESCRIPTION
fix https://github.com/coze-dev/coze-studio/issues/2225