### PR TITLE
knowledge_retrieve add return key

### DIFF
--- a/backend/domain/workflow/internal/nodes/knowledge/knowledge_retrieve.go
+++ b/backend/domain/workflow/internal/nodes/knowledge/knowledge_retrieve.go
@@ -216,6 +216,9 @@ func (kr *Retrieve) Invoke(ctx context.Context, input map[string]any) (map[strin
 		return map[string]any{
 			"documentId": m.Slice.DocumentID,
 			"output":     m.Slice.GetSliceContent(),
+			"score":        m.Score,
+			"documentName": m.Slice.DocumentName,
+			"documentUrl":  m.Slice.Extra["document_url"],
 		}
 	})
 


### PR DESCRIPTION
Add score, documentName, and documentUrl to the knowledge base retrieval results. This enables more data from the knowledge base to be utilized during the agent's operation for subsequent logical processing.
 
