### PR TITLE
fix: enable virtual hosted style for S3 client

### DIFF
--- a/backend/infra/storage/impl/s3/s3.go
+++ b/backend/infra/storage/impl/s3/s3.go
@@ -57,7 +57,7 @@ func getS3Client(ctx context.Context, ak, sk, bucketName, endpoint, region strin
 			PartitionID:       "aws",
 			URL:               endpoint,
 			SigningRegion:     region,
-			HostnameImmutable: true,
+			HostnameImmutable: false,
 			Source:            aws.EndpointSourceCustom,
 		}, nil
 	})


### PR DESCRIPTION
#### What type of PR is this?

fix: enable virtual hosted style for S3 client

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Add documentation if the current PR requires user awareness at the usage level.


#### (Optional) Translate the PR title into Chinese.

使现有的S3Client能使用只支持virtual hosted style的S3 API

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:
Tencent Cloud and Alibaba Cloud object storage currently only support virtual hosted style. In the existing code, the domain name was set as immutable, which prevented the AWS SDK from modifying the endpoint. This caused 403 errors when calling related APIs, making it impossible to properly connect to the S3 APIs provided by cloud service providers.
Therefore, the HostnameImmutable setting has been changed to false to enable support for virtual hosted style.
zh(optional): 
腾讯云和阿里云提供的对象存储目前都只支持virtual hosted style, 现有代码中, 将域名设置为了Immutable, 导致aws的sdk没法修改endpoint, 使得调用相关接口时会403, 没法正常接入云服务商提供的s3 API.
所以将ImmutableHost设置为flase, 使得可以支持virtual hosted style

#### (Optional) Which issue(s) this PR fixes:
Fixed #2307 
