### PR TITLE
fix: sync legacy model EnableBase64Url config and handle not found er…

### DIFF
--- a/backend/bizpkg/config/modelmgr/deprecate_model_get.go
+++ b/backend/bizpkg/config/modelmgr/deprecate_model_get.go
@@ -282,6 +282,10 @@ func toNewModel(old *OldModel) (*Model, error) {
 		m.Connection.Claude = modelMeta.Connection.Claude
 	}
 
+	if old.Meta.ConnConfig.EnableBase64Url != nil {
+		m.EnableBase64URL = *old.Meta.ConnConfig.EnableBase64Url
+	}
+
 	logs.Debugf("to new model, old: %v \n new %v",
 		conv.DebugJsonToStr(old), conv.DebugJsonToStr(m))
 
@@ -360,6 +364,7 @@ type OldConfig struct {
 	TopK             *int     `json:"top_k,omitempty" yaml:"top_k"`
 	Stop             []string `json:"stop,omitempty" yaml:"stop"`
 	EnableThinking   *bool    `json:"enable_thinking,omitempty" yaml:"enable_thinking,omitempty"`
+	EnableBase64Url  *bool    `json:"enable_base64_url,omitempty" yaml:"enable_base64_url,omitempty"`
 
 	OpenAI   *OpenAIConfig   `json:"open_ai,omitempty" yaml:"openai"`
 	Claude   *ClaudeConfig   `json:"claude,omitempty" yaml:"claude"`


### PR DESCRIPTION
1. Sync the EnableBase64Url configuration for legacy models.
2. Handle not found error in GetPublishedInfo.