### PR TITLE
fix(plugin): update plugin invocation and request encoding logic, fix the problem that the default value of the conversation flow call plugin was not handled correctly, which added an extra quote; add botId, userId, conversationId to the header when the conversation flow call plugin makes a request

### DIFF
--- a/backend/domain/plugin/internal/encoder/req_encode.go
+++ b/backend/domain/plugin/internal/encoder/req_encode.go
@@ -257,6 +257,8 @@ func MustString(value any) string {
 	switch val := value.(type) {
 	case string:
 		return val
+	case *string:
+		return *val
 	default:
 		b, _ := json.Marshal(val)
 		return string(b)
@@ -323,6 +325,11 @@ func tryCorrectString(value any) (string, error) {
 	switch val := value.(type) {
 	case string:
 		return val, nil
+	case *string:
+		if val == nil {
+			return "", nil
+		}
+		return *val, nil
 	case int64:
 		return strconv.FormatInt(val, 10), nil
 	case float64:


### PR DESCRIPTION
修复问题：

1. 在会话流中调用插件，插件默认字符串在为对模型开启的情况下，默认字符串没有正确处理：多加了一个引号
![img_v3_02rb_c009cdce-942c-46b1-9ee7-89908208635g](https://github.com/user-attachments/assets/e5993917-be50-44d5-99ac-0924fdcc88ea)

2. 在会话流中调用插件，正确在请求头中传递 botId、userId 和 conversationId