### PR TITLE
fix(plugin): Resolves the issue where calling plugins in the workflow fails to pass the ConversationID and AgentID to the plugin service.

### DIFF
--- a/backend/crossdomain/plugin/model/option.go
+++ b/backend/crossdomain/plugin/model/option.go
@@ -70,7 +70,7 @@ func WithAutoGenRespSchema() ExecuteToolOpt {
 	}
 }
 
-func WithPluginHTTPHeader(conversationID int64) ExecuteToolOpt {
+func WithConversationID(conversationID int64) ExecuteToolOpt {
 	return func(o *ExecuteToolOption) {
 		o.ConversationID = conversationID
 	}

--- a/backend/domain/agent/singleagent/internal/agentflow/node_tool_plugin.go
+++ b/backend/domain/agent/singleagent/internal/agentflow/node_tool_plugin.go
@@ -136,7 +136,7 @@ func (p *pluginInvokableTool) InvokableRun(ctx context.Context, argumentsInJSON 
 		model.WithInvalidRespProcessStrategy(consts.InvalidResponseProcessStrategyOfReturnDefault),
 		model.WithToolVersion(p.toolInfo.GetVersion()),
 		model.WithProjectInfo(p.projectInfo),
-		model.WithPluginHTTPHeader(p.conversationID),
+		model.WithConversationID(p.conversationID),
 	}
 
 	resp, err := crossplugin.DefaultSVC().ExecuteTool(ctx, req, opts...)

--- a/backend/domain/workflow/internal/nodes/plugin/exec.go
+++ b/backend/domain/workflow/internal/nodes/plugin/exec.go
@@ -65,6 +65,14 @@ func ExecutePlugin(ctx context.Context, input map[string]any, pe *vo.PluginEntit
 	if pe.PluginVersion != nil {
 		execOpts = append(execOpts, model.WithToolVersion(*pe.PluginVersion))
 	}
+	if cfg.ConversationID != nil {
+		execOpts = append(execOpts, model.WithConversationID(*cfg.ConversationID))
+	}
+	if cfg.AgentID != nil {
+		execOpts = append(execOpts, model.WithProjectInfo(&model.ProjectInfo{
+			ProjectID: *cfg.AgentID,
+		}))
+	}
 
 	r, err := crossplugin.DefaultSVC().ExecuteTool(ctx, req, execOpts...)
 	if err != nil {


### PR DESCRIPTION
fix(plugin): 解决 #2418 ，在工作流中没有正确传递UserId 和 没有传递 ConversationID、AgentID 给 插件的问题。

- 将WithPluginHTTPHeader重命名为WithConversationID以准确反映其用途
- 在工作流节点中增加对ConversationID和AgentID的传递支持
- 解决工作流中模型调用插件，没有正确传递 UserID 的问题。

