### PR TITLE
fix: always select ID in GetAll pagination to prevent infinite loop

### DIFF
--- a/backend/domain/app/internal/dal/app_release_record.go
+++ b/backend/domain/app/internal/dal/app_release_record.go
@@ -72,10 +72,9 @@ func (r *APPReleaseRecordDAO) getSelected(opt *APPSelectedOption) (selected []fi
 	}
 
 	table := r.query.AppReleaseRecord
+	// Always include ID, it may be used as cursor in pagination loops
+	selected = append(selected, table.ID)
 
-	if opt.PublishRecordID {
-		selected = append(selected, table.ID)
-	}
 	if opt.APPID {
 		selected = append(selected, table.AppID)
 	}

--- a/backend/domain/plugin/internal/dal/agent_tool_draft.go
+++ b/backend/domain/plugin/internal/dal/agent_tool_draft.go
@@ -67,6 +67,7 @@ func (at *AgentToolDraftDAO) getSelected(opt *ToolSelectedOption) (selected []fi
 	}
 
 	table := at.query.AgentToolDraft
+	// Always include ID, it may be used as cursor in pagination loops
 	selected = append(selected, table.ID)
 
 	if opt.ToolID {

--- a/backend/domain/plugin/internal/dal/plugin.go
+++ b/backend/domain/plugin/internal/dal/plugin.go
@@ -72,10 +72,9 @@ func (p *PluginDAO) getSelected(opt *PluginSelectedOption) (selected []field.Exp
 	}
 
 	table := p.query.Plugin
+	// Always include ID, it may be used as cursor in pagination loops
+	selected = append(selected, table.ID)
 
-	if opt.PluginID {
-		selected = append(selected, table.ID)
-	}
 	if opt.OpenapiDoc {
 		selected = append(selected, table.OpenapiDoc)
 	}

--- a/backend/domain/plugin/internal/dal/plugin_draft.go
+++ b/backend/domain/plugin/internal/dal/plugin_draft.go
@@ -72,10 +72,9 @@ func (p *PluginDraftDAO) getSelected(opt *PluginSelectedOption) (selected []fiel
 	}
 
 	table := p.query.PluginDraft
+	// Always include ID, it may be used as cursor in pagination loops
+	selected = append(selected, table.ID)
 
-	if opt.PluginID {
-		selected = append(selected, table.ID)
-	}
 	if opt.OpenapiDoc {
 		selected = append(selected, table.OpenapiDoc)
 	}

--- a/backend/domain/plugin/internal/dal/plugin_version.go
+++ b/backend/domain/plugin/internal/dal/plugin_version.go
@@ -71,6 +71,8 @@ func (p *PluginVersionDAO) getSelected(opt *PluginSelectedOption) (selected []fi
 	}
 
 	table := p.query.PluginVersion
+	// Always include ID, it may be used as cursor in pagination loops
+	selected = append(selected, table.ID)
 
 	if opt.PluginID {
 		selected = append(selected, table.PluginID)

--- a/backend/domain/plugin/internal/dal/tool.go
+++ b/backend/domain/plugin/internal/dal/tool.go
@@ -67,10 +67,9 @@ func (t *ToolDAO) getSelected(opt *ToolSelectedOption) (selected []field.Expr) {
 	}
 
 	table := t.query.Tool
-
-	if opt.ToolID {
-		selected = append(selected, table.ID)
-	}
+	// Always include ID, it may be used as cursor in pagination loops
+	selected = append(selected, table.ID)
+	
 	if opt.ActivatedStatus {
 		selected = append(selected, table.ActivatedStatus)
 	}

--- a/backend/domain/plugin/internal/dal/tool_draft.go
+++ b/backend/domain/plugin/internal/dal/tool_draft.go
@@ -71,10 +71,9 @@ func (t *ToolDraftDAO) getSelected(opt *ToolSelectedOption) (selected []field.Ex
 	}
 
 	table := t.query.ToolDraft
+	// Always include ID, it may be used as cursor in pagination loops
+	selected = append(selected, table.ID)
 
-	if opt.ToolID {
-		selected = append(selected, table.ID)
-	}
 	if opt.ActivatedStatus {
 		selected = append(selected, table.ActivatedStatus)
 	}


### PR DESCRIPTION
issues地址：https://github.com/coze-dev/coze-studio/issues/2496

backend/domain/plugin/internal/dal/model/agent_tool_draft.gen.go第149-180行GetAll()函数中。
使用分页的逻辑来查询工具，分页的游标为ID，但是在select语句中，没有加上ID这个参数，导致只要是数据达到20，该分页的for循环就会陷入死循环。opencoze和mysql的cpu会激增最终导致系统死机。

修复：
在getSelected中加上ID选择