### PR TITLE
fix(chatflow): support assistant role and fix message ordering for additional_messages

### DIFF
--- a/backend/application/workflow/chatflow.go
+++ b/backend/application/workflow/chatflow.go
@@ -52,7 +52,6 @@ import (
 	"github.com/coze-dev/coze-studio/backend/pkg/logs"
 	"github.com/coze-dev/coze-studio/backend/pkg/safego"
 	"github.com/coze-dev/coze-studio/backend/pkg/sonic"
-	"github.com/coze-dev/coze-studio/backend/pkg/taskgroup"
 	"github.com/coze-dev/coze-studio/backend/types/consts"
 	"github.com/coze-dev/coze-studio/backend/types/errno"
 )
@@ -642,6 +641,22 @@ func (w *ApplicationService) OpenAPIChatFlowRun(ctx context.Context, req *workfl
 		sectionID = sID
 	}
 
+	// 先处理历史消息（additional_messages 中除最后一条外的所有消息）
+	// 确保历史消息的 CreatedAt 早于当前用户消息，使 prefetchChatHistory 的跳过逻辑正确工作
+	messageClient := crossmessage.DefaultSVC()
+	historyMessages, err := makeChatFlowHistoryMessages(ctx, bizID, conversationID, userID, sectionID, connectorID, messages[:len(req.GetAdditionalMessages())-1])
+	if err != nil {
+		return nil, err
+	}
+
+	if len(historyMessages) > 0 {
+		_, err := messageClient.BatchCreate(ctx, historyMessages)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// 再创建当前轮次的 runRecord 和用户消息
 	runRecord, err := crossagentrun.DefaultSVC().Create(ctx, &agententity.AgentRunMeta{
 		AgentID:        bizID,
 		ConversationID: conversationID,
@@ -660,7 +675,6 @@ func (w *ApplicationService) OpenAPIChatFlowRun(ctx context.Context, req *workfl
 		return nil, err
 	}
 
-	messageClient := crossmessage.DefaultSVC()
 	_, err = messageClient.Create(ctx, userMessage)
 	if err != nil {
 		return nil, err
@@ -743,28 +757,6 @@ func (w *ApplicationService) OpenAPIChatFlowRun(ctx context.Context, req *workfl
 		Cancellable: isDebug,
 	}
 
-	historyMessages, err := makeChatFlowHistoryMessages(ctx, bizID, conversationID, userID, sectionID, connectorID, messages[:len(req.GetAdditionalMessages())-1])
-	if err != nil {
-		return nil, err
-	}
-
-	if len(historyMessages) > 0 {
-		g := taskgroup.NewTaskGroup(ctx, len(historyMessages))
-		for _, hm := range historyMessages {
-			hMsg := hm
-			g.Go(func() error {
-				_, err := messageClient.Create(ctx, hMsg)
-				if err != nil {
-					return err
-				}
-				return nil
-			})
-		}
-		err = g.Wait()
-		if err != nil {
-			logs.CtxWarnf(ctx, "create history message failed, err=%v", err)
-		}
-	}
 	parameters[vo.UserInputKey], err = w.makeChatFlowUserInput(ctx, lastUserMessage)
 	if err != nil {
 		return nil, err
@@ -1226,8 +1218,9 @@ func makeChatFlowHistoryMessages(ctx context.Context, bizID, conversationID, use
 	)
 
 	historyMessages := make([]*message.Message, 0, len(messages))
+	baseTimestamp := time.Now().UnixMilli() - int64(len(messages)*1000)
 
-	for _, msg := range messages {
+	for i, msg := range messages {
 		if msg.Role == userRole {
 			runRecord, err = crossagentrun.DefaultSVC().Create(ctx, &agententity.AgentRunMeta{
 				AgentID:        bizID,
@@ -1253,6 +1246,7 @@ func makeChatFlowHistoryMessages(ctx context.Context, bizID, conversationID, use
 			return nil, err
 		}
 
+		m.CreatedAt = baseTimestamp + int64(i*100)
 		historyMessages = append(historyMessages, m)
 
 	}
@@ -1359,7 +1353,7 @@ func toConversationMessage(ctx context.Context, bizID, cid, userID, roundID, sec
 	}
 	if msg.ContentType == "text" {
 		return &message.Message{
-			Role:           schema.User,
+			Role:           schema.RoleType(msg.Role),
 			ConversationID: cid,
 			AgentID:        bizID,
 			RunID:          roundID,
@@ -1378,7 +1372,7 @@ func toConversationMessage(ctx context.Context, bizID, cid, userID, roundID, sec
 		}
 
 		m := &message.Message{
-			Role:           schema.User,
+			Role:           schema.RoleType(msg.Role),
 			MessageType:    messageType,
 			ConversationID: cid,
 			AgentID:        bizID,


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.


#### (Optional) Translate the PR title into Chinese.
fix(chatflow): additional_messages支持 assistant 角色并修复消息顺序问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: This PR fixes several issues in chatflow related to additional_messages handling:

Support Multiple Roles: Previously, roles in additional_messages were hardcoded to user. This PR enables proper mapping to support roles like assistant.
Fix Message Duplication: Adjusted the creation sequence so that history messages (from additional_messages) are created before the current run and user message. This ensures their CreatedAt timestamps are earlier, allowing prefetchChatHistory to correctly skip existing messages and preventing duplication.
Guaranteed Sequential Order: Implemented manual timestamp management for history messages and switched to BatchCreate to ensure strict chronological order when stored in the database.


zh: 此 PR 修复了 chatflow 处理 additional_messages 时的几个关键问题：

支持多种角色：修复了之前 additional_messages 中角色被硬编码为 user 的问题，现在能正确识别并支持 assistant 等角色。
修复消息重复：调整了创建顺序，确保 additional_messages 中的历史消息在当前最新轮次user 的 Run Record 和消息之前创建。这保证了历史消息的 CreatedAt 时间戳更早，从而让 prefetchChatHistory 的跳过逻辑能正常工作，避免了取回历史消息时出现的重复问题。
保证消息顺序：为历史消息引入了手动的时间戳增量逻辑，并从并发创建改为 BatchCreate（批量创建），确保消息在数据库中严格按序排列，防止获取最新消息时顺序错乱。
代码变更要点回顾：
角色映射：在 toConversationMessage 中将 Role: schema.User 修改为 Role: schema.RoleType(msg.Role)。
创建时序：将 makeChatFlowHistoryMessages 和 BatchCreate 的调用移到了 OpenAPIChatFlowRun 的最开始部分。
时间戳管理：在 makeChatFlowHistoryMessages 中通过 baseTimestamp + int64(i*100) 为每条历史消息分配了递增的时间戳。
性能优化：移除了 taskgroup 的并发创建，改用一次 BatchCreate 提交，既保证了顺序又提高了效率。


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
