### PR TITLE
fix(plugin): allow duplicate parameter names across different locations

### DIFF
--- a/backend/crossdomain/plugin/model/openapi.go
+++ b/backend/crossdomain/plugin/model/openapi.go
@@ -229,7 +229,7 @@ func (op *Openapi3Operation) ToEinoSchemaParameterInfo(ctx context.Context) (map
 		}
 
 		if _, ok := result[paramVal.Name]; ok {
-			logs.CtxWarnf(ctx, "duplicate parameter name '%s'", paramVal.Name)
+			logs.CtxWarnf(ctx, "duplicate parameter name '%s' in location '%s', skipping (first occurrence kept)", paramVal.Name, paramVal.In)
 			continue
 		}
 
@@ -260,7 +260,7 @@ func (op *Openapi3Operation) ToEinoSchemaParameterInfo(ctx context.Context) (map
 			}
 
 			if _, ok := result[paramName]; ok {
-				logs.CtxWarnf(ctx, "duplicate parameter name '%s'", paramName)
+				logs.CtxWarnf(ctx, "duplicate parameter name '%s' in request body, skipping (first occurrence kept)", paramName)
 				continue
 			}
 

--- a/frontend/packages/agent-ide/bot-plugin/tools/src/components/plugin_modal/utils.ts
+++ b/frontend/packages/agent-ide/bot-plugin/tools/src/components/plugin_modal/utils.ts
@@ -366,7 +366,7 @@ export const handleIsShowDelete = (
   return isShowDelete(data, targetKey);
 };
 
-// Check if the same name exists
+// Check if the same name exists in the same location
 export const checkSameName = (
   data: Array<APIParameter>,
   targetKey: string,
@@ -374,8 +374,10 @@ export const checkSameName = (
 ): boolean | undefined => {
   for (const item of data) {
     if (item[ROWKEY] === targetKey) {
+      // Filter by both name and location to allow same names in different locations
       const items = data.filter(
-        (dataItem: APIParameter) => dataItem.name === val,
+        (dataItem: APIParameter) =>
+          dataItem.name === val && dataItem.location === item.location,
       );
       return items.length > 1;
     } else if (


### PR DESCRIPTION
## Summary

This PR enables plugins to have parameters with the same name in different HTTP locations (Header/Body/Query/Path), which is valid according to OpenAPI specification.

## Problem

Previously, when a plugin API had parameters with the same name in different locations (e.g., `id` in both query and body), the frontend would show "参数名称不能重复" error, and the backend would only keep the first occurrence.

## Solution

### Frontend
- Updated `checkSameName` function to validate uniqueness only within the same location
- Users can now create parameters with same names in different locations

### Backend
- `ToEinoSchemaParameterInfo`: Use `location-name` format as map key (e.g., `query-id`, `body-name`)
- `groupedRequestArgs`: Parse `location-name` format keys and route values to correct HTTP request parts

## How it works

1. User configures parameters in UI - frontend allows same names in different locations
2. Backend generates keys like `query-id`, `body-id` for LLM
3. LLM calls with `{"query-id": "xxx", "body-id": "yyy"}`
4. `groupedRequestArgs` parses keys, routes `xxx` to query params, `yyy` to body

## Files Changed

- `frontend/.../plugin_modal/utils.ts` - Frontend validation
- `backend/.../openapi.go` - Parameter key generation
- `backend/.../invocation_args.go` - Parameter parsing

## Testing

- [x] Backend compiles successfully
- [ ] Manual testing with plugin that has same-name parameters in different locations