### PR TITLE
fix: MySQL init script by selecting database

### DIFF
--- a/docker/volumes/mysql/schema.sql
+++ b/docker/volumes/mysql/schema.sql
@@ -1,5 +1,6 @@
 SET NAMES utf8mb4;
 CREATE DATABASE IF NOT EXISTS opencoze COLLATE utf8mb4_unicode_ci;
+USE opencoze;
 -- Create 'agent_to_database' table
 CREATE TABLE IF NOT EXISTS `agent_to_database` (`id` bigint unsigned NOT NULL COMMENT 'ID', `agent_id` bigint unsigned NOT NULL COMMENT 'Agent ID', `database_id` bigint unsigned NOT NULL COMMENT 'ID of database_info', `is_draft` bool NOT NULL COMMENT 'Is draft', `prompt_disable` bool NOT NULL DEFAULT 0 COMMENT 'Support prompt calls: 1 not supported, 0 supported', PRIMARY KEY (`id`), UNIQUE INDEX `uniq_agent_db_draft` (`agent_id`, `database_id`, `is_draft`)) ENGINE=InnoDB CHARSET utf8mb4 COLLATE utf8mb4_general_ci COMMENT 'agent_to_database info';
 -- Create 'agent_tool_draft' table


### PR DESCRIPTION
## What
Add `USE opencoze;` to the MySQL init script.

## Why
MySQL init logs show: ERROR 1046 (3D000) No database selected, so tables fail to create.

## How
- Insert `USE opencoze;` after `CREATE DATABASE IF NOT EXISTS opencoze ...`
- File: docker/volumes/mysql/schema.sql

## Testing
Not run (SQL init only).

Fixes #2605