### PR TITLE
fix(workflow): prevent JSON parsing failures from LLM <think> blocks

### DIFF
--- a/backend/domain/workflow/internal/nodes/llm/llm.go
+++ b/backend/domain/workflow/internal/nodes/llm/llm.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -887,6 +888,8 @@ const (
 )
 
 func jsonParse(ctx context.Context, data string, schema_ map[string]*vo.TypeInfo) (map[string]any, error) {
+	re := regexp.MustCompile(`<(think)>(\W|\w)*</think>`)
+	data = re.ReplaceAllString(data, "")
 	data = nodes.ExtractJSONString(data)
 
 	var result map[string]any


### PR DESCRIPTION
fix(workflow): remove `think` tags before JSON parsing

When parsing LLM responses, some replies include `<think>...</think>` tags (internal reasoning), which may break JSON parsing. This PR strips all `<think>...</think>` blocks via regex before attempting to parse, making JSON extraction stable.

#### What type of PR is this?
- [x] fix

#### Check the PR title.
- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.
fix(workflow): 在解析 JSON 前移除 `think` 标签

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:
- Problem: Some LLM outputs wrap internal reasoning in `<think>...</think>`, causing JSON parsing to fail.
- Solution: Remove all `<think>...</think>` segments before JSON parsing using a regex pre-processing step.
- Impact: Improves robustness of JSON extraction; no functional change for valid JSON responses.

zh(optional):
- 问题：部分 LLM 输出包含 `<think>...</think>`，会导致 JSON 解析失败。
- 方案：在解析 JSON 前用正则移除所有 `<think>...</think>` 段落。
- 影响：提升 JSON 提取稳定性；对原本就合法的 JSON 输出无影响。

#### (Optional) Which issue(s) this PR fixes:
N/A