### PR TITLE
fix(workflow): prevent NodePath corruption for nested sub-workflows in loop/batch

### DIFF
--- a/backend/domain/workflow/internal/compose/test/batch_test.go
+++ b/backend/domain/workflow/internal/compose/test/batch_test.go
@@ -362,12 +362,22 @@ func TestBatch(t *testing.T) {
 type mockRepo struct {
 	workflow.Repository
 	mu     sync.Mutex
+	nextID int64
 	events []*entity.InterruptEvent
 	cp     map[string][]byte
 }
 
 func (m *mockRepo) GenID(ctx context.Context) (int64, error) {
-	return 10001, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextID++
+	return m.nextID, nil
+}
+
+func (m *mockRepo) getNextID() int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.nextID
 }
 
 func (m *mockRepo) ListInterruptEvents(ctx context.Context, wfExeID int64) ([]*entity.InterruptEvent, error) {

--- a/backend/domain/workflow/internal/compose/test/loop_test.go
+++ b/backend/domain/workflow/internal/compose/test/loop_test.go
@@ -19,21 +19,26 @@ package test
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/bytedance/mockey"
 	"github.com/cloudwego/eino/compose"
 	"github.com/stretchr/testify/assert"
 
+	model "github.com/coze-dev/coze-studio/backend/crossdomain/workflow/model"
+	"github.com/coze-dev/coze-studio/backend/domain/workflow"
 	"github.com/coze-dev/coze-studio/backend/domain/workflow/entity"
 	"github.com/coze-dev/coze-studio/backend/domain/workflow/entity/vo"
 	compose2 "github.com/coze-dev/coze-studio/backend/domain/workflow/internal/compose"
+	"github.com/coze-dev/coze-studio/backend/domain/workflow/internal/execute"
 	"github.com/coze-dev/coze-studio/backend/domain/workflow/internal/nodes"
 	"github.com/coze-dev/coze-studio/backend/domain/workflow/internal/nodes/entry"
 	"github.com/coze-dev/coze-studio/backend/domain/workflow/internal/nodes/exit"
 	"github.com/coze-dev/coze-studio/backend/domain/workflow/internal/nodes/loop"
 	_break "github.com/coze-dev/coze-studio/backend/domain/workflow/internal/nodes/loop/break"
 	_continue "github.com/coze-dev/coze-studio/backend/domain/workflow/internal/nodes/loop/continue"
+	"github.com/coze-dev/coze-studio/backend/domain/workflow/internal/nodes/subworkflow"
 	"github.com/coze-dev/coze-studio/backend/domain/workflow/internal/nodes/variableassigner"
 	"github.com/coze-dev/coze-studio/backend/domain/workflow/internal/schema"
 	"github.com/coze-dev/coze-studio/backend/pkg/lang/ptr"
@@ -728,4 +733,238 @@ func TestLoop_Interrupt(t *testing.T) {
 	// 1 from resuming index 0
 	// 1 from running index 1 fresh
 	assert.Equal(t, 3, callCount)
+}
+
+func TestLoop_SubWorkflow_Nested_Interrupt(t *testing.T) {
+	ctx := context.Background()
+
+	var callCount atomic.Int64
+
+	lambdaNode := &schema.NodeSchema{
+		Key:     "lambda",
+		Type:    entity.NodeTypeLambda,
+		Configs: &interruptibleConfig{},
+		Lambda: compose.InvokableLambda(func(ctx context.Context, in map[string]any) (map[string]any, error) {
+			n := callCount.Add(1)
+			t.Logf("lambda invoked (call #%d)", n)
+
+			if n == 1 {
+				interruptEvent := &entity.InterruptEvent{
+					ID:            n,
+					NodeKey:       "lambda",
+					EventType:     entity.InterruptEventInput,
+					InterruptData: "{}",
+				}
+				return nil, compose.NewInterruptAndRerunErr(interruptEvent)
+			}
+			return map[string]any{"output": "done"}, nil
+		}, compose.WithLambdaType(string(entity.NodeTypeLambda))),
+	}
+
+	innerSubWfSchema := &schema.WorkflowSchema{
+		Nodes: []*schema.NodeSchema{
+			{Key: entity.EntryNodeKey, Type: entity.NodeTypeEntry, Configs: &entry.Config{}},
+			lambdaNode,
+			{Key: entity.ExitNodeKey, Type: entity.NodeTypeExit, Configs: &exit.Config{TerminatePlan: vo.ReturnVariables},
+				InputSources: []*vo.FieldInfo{
+					{
+						Path: compose.FieldPath{"output"},
+						Source: vo.FieldSource{
+							Ref: &vo.Reference{FromNodeKey: "lambda", FromPath: compose.FieldPath{"output"}},
+						},
+					},
+				},
+			},
+		},
+		Connections: []*schema.Connection{
+			{FromNode: entity.EntryNodeKey, ToNode: "lambda"},
+			{FromNode: "lambda", ToNode: entity.ExitNodeKey},
+		},
+	}
+	innerSubWfSchema.Init()
+
+	innerSubWfNode := &schema.NodeSchema{
+		Key:               "inner_sub_wf",
+		Type:              entity.NodeTypeSubWorkflow,
+		Configs:           &subworkflow.Config{WorkflowID: 200},
+		SubWorkflowSchema: innerSubWfSchema,
+		SubWorkflowBasic:  &entity.WorkflowBasic{ID: 200, Version: "1"},
+		OutputSources: []*vo.FieldInfo{
+			{
+				Path: compose.FieldPath{"output"},
+				Source: vo.FieldSource{
+					Ref: &vo.Reference{FromNodeKey: entity.ExitNodeKey, FromPath: compose.FieldPath{"output"}},
+				},
+			},
+		},
+	}
+
+	outerSubWfSchema := &schema.WorkflowSchema{
+		Nodes: []*schema.NodeSchema{
+			{Key: entity.EntryNodeKey, Type: entity.NodeTypeEntry, Configs: &entry.Config{}},
+			innerSubWfNode,
+			{Key: entity.ExitNodeKey, Type: entity.NodeTypeExit, Configs: &exit.Config{TerminatePlan: vo.ReturnVariables},
+				InputSources: []*vo.FieldInfo{
+					{
+						Path: compose.FieldPath{"output"},
+						Source: vo.FieldSource{
+							Ref: &vo.Reference{FromNodeKey: "inner_sub_wf", FromPath: compose.FieldPath{"output"}},
+						},
+					},
+				},
+			},
+		},
+		Connections: []*schema.Connection{
+			{FromNode: entity.EntryNodeKey, ToNode: "inner_sub_wf"},
+			{FromNode: "inner_sub_wf", ToNode: entity.ExitNodeKey},
+		},
+	}
+	outerSubWfSchema.Init()
+
+	outerSubWfNode := &schema.NodeSchema{
+		Key:               "outer_sub_wf",
+		Type:              entity.NodeTypeSubWorkflow,
+		Configs:           &subworkflow.Config{WorkflowID: 100},
+		SubWorkflowSchema: outerSubWfSchema,
+		SubWorkflowBasic:  &entity.WorkflowBasic{ID: 100, Version: "1"},
+		OutputSources: []*vo.FieldInfo{
+			{
+				Path: compose.FieldPath{"output"},
+				Source: vo.FieldSource{
+					Ref: &vo.Reference{FromNodeKey: entity.ExitNodeKey, FromPath: compose.FieldPath{"output"}},
+				},
+			},
+		},
+	}
+
+	continueNode := &schema.NodeSchema{
+		Key:     "continueNode",
+		Type:    entity.NodeTypeContinue,
+		Configs: &_continue.Config{},
+	}
+
+	loopNode := &schema.NodeSchema{
+		Key:  "loop_node",
+		Type: entity.NodeTypeLoop,
+		Configs: &loop.Config{
+			LoopType: loop.ByIteration,
+		},
+		InputSources: []*vo.FieldInfo{
+			{
+				Path:   compose.FieldPath{loop.Count},
+				Source: vo.FieldSource{Ref: &vo.Reference{FromNodeKey: entity.EntryNodeKey, FromPath: compose.FieldPath{"count"}}},
+			},
+		},
+		OutputSources: []*vo.FieldInfo{
+			{
+				Path: compose.FieldPath{"loop_output"},
+				Source: vo.FieldSource{
+					Ref: &vo.Reference{FromNodeKey: "outer_sub_wf", FromPath: compose.FieldPath{"output"}},
+				},
+			},
+		},
+	}
+
+	ws := &schema.WorkflowSchema{
+		Nodes: []*schema.NodeSchema{
+			{Key: entity.EntryNodeKey, Type: entity.NodeTypeEntry, Configs: &entry.Config{}},
+			loopNode,
+			outerSubWfNode,
+			continueNode,
+			{Key: entity.ExitNodeKey, Type: entity.NodeTypeExit, Configs: &exit.Config{TerminatePlan: vo.ReturnVariables},
+				InputSources: []*vo.FieldInfo{
+					{
+						Path: compose.FieldPath{"loop_output"},
+						Source: vo.FieldSource{
+							Ref: &vo.Reference{FromNodeKey: "loop_node", FromPath: compose.FieldPath{"loop_output"}},
+						},
+					},
+				},
+			},
+		},
+		Hierarchy: map[vo.NodeKey]vo.NodeKey{
+			"outer_sub_wf": "loop_node",
+			"continueNode": "loop_node",
+		},
+		Connections: []*schema.Connection{
+			{FromNode: entity.EntryNodeKey, ToNode: "loop_node"},
+			{FromNode: "loop_node", ToNode: "outer_sub_wf"},
+			{FromNode: "outer_sub_wf", ToNode: "continueNode"},
+			{FromNode: "continueNode", ToNode: "loop_node"},
+			{FromNode: "loop_node", ToNode: entity.ExitNodeKey},
+		},
+	}
+	ws.Init()
+
+	basic := &entity.WorkflowBasic{ID: 1, Version: "1"}
+
+	myRepo := &mockRepo{}
+	mockPatch := mockey.Mock(workflow.GetRepository).To(func() workflow.Repository {
+		return myRepo
+	}).Build()
+	defer mockPatch.UnPatch()
+
+	initialRunner := compose2.NewWorkflowRunner(basic, ws, model.ExecuteConfig{})
+	initialCtx, executeID, opts, _, err := initialRunner.Prepare(ctx)
+	assert.NoError(t, err)
+
+	wf, err := compose2.NewWorkflow(initialCtx, ws, compose2.WithIDAsName(basic.ID))
+	assert.NoError(t, err)
+
+	_, err = wf.Runner.Invoke(initialCtx, map[string]any{
+		"count": int64(1),
+	}, opts...)
+
+	assert.Error(t, err)
+	info, existed := compose.ExtractInterruptInfo(err)
+	assert.True(t, existed)
+	assert.NotNil(t, info)
+	assert.Equal(t, int64(1), callCount.Load(),
+		"Lambda should have been called exactly once (loop has 1 item, interrupted on first call)")
+
+	repo := workflow.GetRepository()
+	event0, found, _ := repo.GetFirstInterruptEvent(ctx, executeID)
+	assert.True(t, found)
+	assert.NotNil(t, event0)
+	if event0 == nil {
+		t.Fatal("interrupt event is nil, cannot proceed with resume")
+	}
+
+	t.Logf("Interrupt event NodePath: %v", event0.NodePath)
+
+	resumeRunner := compose2.NewWorkflowRunner(basic, ws, model.ExecuteConfig{},
+		compose2.WithResumeReq(&entity.ResumeRequest{
+			ExecuteID:  executeID,
+			EventID:    event0.ID,
+			ResumeData: "resumed",
+		}))
+
+	resumeCtx, _, resumeOpts, _, err := resumeRunner.Prepare(ctx)
+	assert.NoError(t, err)
+
+	var wrongPrepareSubExeCtxCalled atomic.Bool
+	var prepareSubExePatch *mockey.Mocker
+	prepareSubExePatch = mockey.Mock(execute.PrepareSubExeCtx).To(
+		func(ctx context.Context, wb *entity.WorkflowBasic, requireCheckpoint bool) (context.Context, error) {
+			if wb != nil && wb.ID == 200 {
+				wrongPrepareSubExeCtxCalled.Store(true)
+				t.Logf("BUG: PrepareSubExeCtx called for inner_sub_wf (ID=200) during resume — this generates a new sub-execute-ID")
+			}
+			prepareSubExePatch.UnPatch()
+			defer prepareSubExePatch.Patch()
+			return execute.PrepareSubExeCtx(ctx, wb, requireCheckpoint)
+		}).Build()
+	defer prepareSubExePatch.UnPatch()
+
+	_, err = wf.Runner.Invoke(resumeCtx, map[string]any{
+		"count": int64(1),
+	}, resumeOpts...)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, int64(2), callCount.Load(),
+		"Lambda should have been called exactly twice: once for initial interrupt, once for resume")
+
+	assert.False(t, wrongPrepareSubExeCtxCalled.Load(),
+		"PrepareSubExeCtx should NOT be called for inner_sub_wf (ID=200) during resume — it should use restoreWorkflowCtx instead")
 }

--- a/backend/domain/workflow/internal/execute/context.go
+++ b/backend/domain/workflow/internal/execute/context.go
@@ -345,10 +345,10 @@ func PrepareNodeExeCtx(ctx context.Context, nodeKey vo.NodeKey, nodeName string,
 	if c.NodeCtx == nil { // node within top level workflow, also not under composite node
 		newC.NodeCtx.NodePath = []string{string(nodeKey)}
 	} else {
-		if c.BatchInfo == nil {
-			newC.NodeCtx.NodePath = append(c.NodeCtx.NodePath, string(nodeKey))
-		} else {
+		if c.BatchInfo != nil && c.BatchInfo.CompositeNodeKey == c.NodeCtx.NodeKey {
 			newC.NodeCtx.NodePath = append(c.NodeCtx.NodePath, InterruptEventIndexPrefix+strconv.Itoa(c.BatchInfo.Index), string(nodeKey))
+		} else {
+			newC.NodeCtx.NodePath = append(c.NodeCtx.NodePath, string(nodeKey))
 		}
 	}
 


### PR DESCRIPTION
# NodePath Corruption in Nested Sub-Workflows During Resume

## Problem

When a workflow has a **loop containing nested sub-workflows** (loop → sub_wf_A → sub_wf_B → interruptible_node), resuming after interrupt generates **new sub-execute-IDs** for the inner sub-workflow instead of restoring the existing ones. This produces duplicate execution records and re-executes the interrupt node.

The loop has only one item, yet the inner sub-workflow gets a different `SubExecuteID` before interrupt vs after resume.

**Expected:** On resume, `inner_sub_wf` context is restored via `restoreWorkflowCtx` (same SubExecuteID).
**Actual:** On resume, `inner_sub_wf` context is recreated via `PrepareSubExeCtx` (new SubExecuteID).

## Solution

One-line condition fix in `PrepareNodeExeCtx` (context.go).

The `interrupt_event_index_N` prefix was being injected into `NodePath` for **all** descendant nodes when `BatchInfo` was non-nil, not just direct children of the composite node. Since `PrepareSubExeCtx` propagates `BatchInfo` from the composite node into sub-workflow contexts, nodes deep inside nested sub-workflows got a corrupted `NodePath` with a spurious index prefix.

**Before (buggy):**
```go
if c.BatchInfo == nil {
    newC.NodeCtx.NodePath = append(c.NodeCtx.NodePath, string(nodeKey))
} else {
    newC.NodeCtx.NodePath = append(c.NodeCtx.NodePath, InterruptEventIndexPrefix+strconv.Itoa(c.BatchInfo.Index), string(nodeKey))
}
```

**After (fixed):**
```go
if c.BatchInfo != nil && c.BatchInfo.CompositeNodeKey == c.NodeCtx.NodeKey {
    newC.NodeCtx.NodePath = append(c.NodeCtx.NodePath, InterruptEventIndexPrefix+strconv.Itoa(c.BatchInfo.Index), string(nodeKey))
} else {
    newC.NodeCtx.NodePath = append(c.NodeCtx.NodePath, string(nodeKey))
}
```

This aligns `PrepareNodeExeCtx` with the correct condition already used in `initNodeCtx` (callback.go:551-555) — only inject the batch index prefix when the current node **is** the composite node (i.e., the node is a direct child of the loop/batch).

## Key Insight

**`BatchInfo` leaks through `PrepareSubExeCtx` into sub-workflow contexts.** This is by design — the sub-workflow needs `BatchInfo` to report its composite index. However, two `NodePath` construction sites must handle this consistently:

1. `initNodeCtx` (callback.go) — used during resume detection — correctly guards with `c.BatchInfo.CompositeNodeKey == c.NodeCtx.NodeKey`
2. `PrepareNodeExeCtx` (context.go) — used during initial execution — only checked `c.BatchInfo == nil`, causing the prefix to be injected too broadly

The resulting `NodePath` mismatch:
```
Saved:   [loop_node, interrupt_event_index_0, outer_sub_wf, interrupt_event_index_0, inner_sub_wf]
                                                             ^^^^^^^^^^^^^^^^^^^^^^^^ WRONG
Resume:  [loop_node, interrupt_event_index_0, outer_sub_wf, inner_sub_wf, lambda]
```
At index 3, `"interrupt_event_index_0" != "inner_sub_wf"` → resume detection fails → system calls `PrepareSubExeCtx` instead of `restoreWorkflowCtx`.

## Summary

| Problem | Solution |
|---------|----------|
| Nested sub-workflows inside loop/batch get corrupted `NodePath` with spurious batch index prefix | Guard index prefix injection with `CompositeNodeKey == NodeKey` check, matching the existing logic in `initNodeCtx` |
| Inner sub-workflow gets new `SubExecuteID` on resume instead of being restored | Fix ensures `NodePath` matches correctly, so resume detection triggers `restoreWorkflowCtx` |

---

# 嵌套子工作流在循环/批处理中恢复时 NodePath 损坏

## 问题

当工作流的 **循环中嵌套子工作流**（loop → sub_wf_A → sub_wf_B → 可中断节点）时，中断后恢复执行会为内层子工作流**生成新的 SubExecuteID**，而非恢复已有的。这会产生重复的执行记录，并重复执行中断节点。

循环只有一个元素，但内层子工作流在中断前和恢复后获得了不同的 `SubExecuteID`。

**预期行为：** 恢复时，`inner_sub_wf` 通过 `restoreWorkflowCtx` 恢复上下文（相同 SubExecuteID）。
**实际行为：** 恢复时，`inner_sub_wf` 通过 `PrepareSubExeCtx` 重新创建上下文（新 SubExecuteID）。

## 解决方案

在 `PrepareNodeExeCtx`（context.go）中修改一行条件判断。

`interrupt_event_index_N` 前缀在 `BatchInfo` 非空时被注入到**所有**后代节点的 `NodePath` 中，而不仅仅是组合节点的直接子节点。由于 `PrepareSubExeCtx` 会将 `BatchInfo` 从组合节点传播到子工作流上下文中，嵌套子工作流内部的节点会得到一个包含多余索引前缀的错误 `NodePath`。

修复后的条件与 `initNodeCtx`（callback.go:551-555）中已有的正确逻辑保持一致——仅当当前节点**就是**组合节点时（即该节点是 loop/batch 的直接子节点），才注入批次索引前缀。

## 关键洞察

**`BatchInfo` 通过 `PrepareSubExeCtx` 泄漏到子工作流上下文中。** 这是设计如此——子工作流需要 `BatchInfo` 来报告其组合索引。但两个 `NodePath` 构造点必须一致地处理这一情况：

1. `initNodeCtx`（callback.go）——用于恢复检测——正确地使用 `c.BatchInfo.CompositeNodeKey == c.NodeCtx.NodeKey` 守卫
2. `PrepareNodeExeCtx`（context.go）——用于初始执行——仅检查了 `c.BatchInfo == nil`，导致前缀被过度注入

由此产生的 `NodePath` 不匹配导致恢复检测失败，系统调用 `PrepareSubExeCtx`（生成新 SubExecuteID）而非 `restoreWorkflowCtx`（恢复旧的）。

## 总结

| 问题 | 解决方案 |
|------|----------|
| 循环/批处理中的嵌套子工作流 `NodePath` 被错误注入批次索引前缀 | 使用 `CompositeNodeKey == NodeKey` 条件守卫索引前缀注入，与 `initNodeCtx` 中的现有逻辑保持一致 |
| 内层子工作流恢复时获得新 `SubExecuteID` 而非被恢复 | 修复确保 `NodePath` 正确匹配，恢复检测正确触发 `restoreWorkflowCtx` |