### PR TITLE
fix: add server-side nonce validation to OAuth state to prevent CSRF/phishing

### DIFF
--- a/backend/application/application.go
+++ b/backend/application/application.go
@@ -280,6 +280,7 @@ func (b *basicServices) toPluginServiceComponents() *plugin.ServiceComponents {
 		EventBus: b.eventbus.resourceEventBus,
 		OSS:      b.infra.OSS,
 		UserSVC:  b.userSVC.DomainSVC,
+		CacheCli: b.infra.CacheCli,
 	}
 }
 

--- a/backend/application/plugin/init.go
+++ b/backend/application/plugin/init.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coze-dev/coze-studio/backend/domain/plugin/service"
 	search "github.com/coze-dev/coze-studio/backend/domain/search/service"
 	user "github.com/coze-dev/coze-studio/backend/domain/user/service"
+	"github.com/coze-dev/coze-studio/backend/infra/cache"
 	"github.com/coze-dev/coze-studio/backend/infra/idgen"
 	"github.com/coze-dev/coze-studio/backend/infra/storage"
 	"github.com/coze-dev/coze-studio/backend/pkg/errorx"
@@ -39,6 +40,7 @@ type ServiceComponents struct {
 	IDGen    idgen.IDGenerator
 	DB       *gorm.DB
 	OSS      storage.Storage
+	CacheCli cache.Cmdable
 	EventBus search.ResourceEventBus
 	UserSVC  user.User
 }
@@ -68,6 +70,7 @@ func InitService(ctx context.Context, components *ServiceComponents) (*PluginApp
 		IDGen:      components.IDGen,
 		DB:         components.DB,
 		OSS:        components.OSS,
+		CacheCli:   components.CacheCli,
 		PluginRepo: pluginRepo,
 		ToolRepo:   toolRepo,
 		OAuthRepo:  oauthRepo,

--- a/backend/domain/plugin/dto/auth.go
+++ b/backend/domain/plugin/dto/auth.go
@@ -63,6 +63,7 @@ type OAuthState struct {
 	UserID     string        `json:"user_id"`
 	PluginID   int64         `json:"plugin_id"`
 	IsDraft    bool          `json:"is_draft"`
+	Nonce      string        `json:"nonce"`
 }
 
 type AuthorizationCodeMeta struct {

--- a/backend/domain/plugin/internal/dal/cache.go
+++ b/backend/domain/plugin/internal/dal/cache.go
@@ -54,3 +54,8 @@ func (o *OAuthCache) Set(ctx context.Context, key string, value string, expirati
 
 	return cmd.Err()
 }
+
+func (o *OAuthCache) Del(ctx context.Context, key string) error {
+	cmd := o.cacheCli.Del(ctx, key)
+	return cmd.Err()
+}

--- a/backend/domain/plugin/service/exec_tool.go
+++ b/backend/domain/plugin/service/exec_tool.go
@@ -126,7 +126,12 @@ func (p *pluginServiceImpl) acquireAccessTokenIfNeed(ctx context.Context, req *m
 			return "", "", err
 		}
 
-		authURL, err = genAuthURL(ctx, authorizationCode)
+		nonce, err := p.generateOAuthNonce(ctx, authorizationCode.Meta.UserID)
+		if err != nil {
+			return "", "", err
+		}
+
+		authURL, err = genAuthURL(ctx, authorizationCode, nonce)
 		if err != nil {
 			return "", "", err
 		}

--- a/backend/domain/plugin/service/plugin_oauth.go
+++ b/backend/domain/plugin/service/plugin_oauth.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 
 	common "github.com/coze-dev/coze-studio/backend/api/model/plugin_develop/common"
@@ -46,6 +47,11 @@ var (
 	initOnce           = sync.Once{}
 	lastActiveInterval = 15 * 24 * time.Hour
 	failedCache        = sync.Map{}
+)
+
+const (
+	oauthNonceKeyPrefix = "oauth_state_nonce:"
+	oauthNonceTTL       = 10 * time.Minute
 )
 
 func (p *pluginServiceImpl) processOAuthAccessToken(ctx context.Context) {
@@ -275,6 +281,10 @@ func isValidAuthCodeConfig(o, n *model.OAuthAuthorizationCodeConfig, expireAt, l
 }
 
 func (p *pluginServiceImpl) OAuthCode(ctx context.Context, code string, state *dto.OAuthState) (err error) {
+	if err = p.validateOAuthNonce(ctx, state); err != nil {
+		return err
+	}
+
 	var plugin *entity.PluginInfo
 	if state.IsDraft {
 		plugin, err = p.GetDraftPlugin(ctx, state.PluginID)
@@ -430,7 +440,12 @@ func (p *pluginServiceImpl) getPluginOAuthStatus(ctx context.Context, userID int
 
 	needAuth = accessToken == ""
 
-	authURL, err = genAuthURL(ctx, authCode)
+	nonce, err := p.generateOAuthNonce(ctx, authCode.Meta.UserID)
+	if err != nil {
+		return false, "", err
+	}
+
+	authURL, err = genAuthURL(ctx, authCode, nonce)
 	if err != nil {
 		return false, "", err
 	}
@@ -438,7 +453,7 @@ func (p *pluginServiceImpl) getPluginOAuthStatus(ctx context.Context, userID int
 	return needAuth, authURL, nil
 }
 
-func genAuthURL(ctx context.Context, info *dto.AuthorizationCodeInfo) (string, error) {
+func genAuthURL(ctx context.Context, info *dto.AuthorizationCodeInfo, nonce string) (string, error) {
 	config, err := getStanderOAuthConfig(ctx, info.Config)
 	if err != nil {
 		return "", err
@@ -449,6 +464,7 @@ func genAuthURL(ctx context.Context, info *dto.AuthorizationCodeInfo) (string, e
 		UserID:     info.Meta.UserID,
 		PluginID:   info.Meta.PluginID,
 		IsDraft:    info.Meta.IsDraft,
+		Nonce:      nonce,
 	}
 	stateStr, err := json.Marshal(state)
 	if err != nil {
@@ -468,6 +484,38 @@ func genAuthURL(ctx context.Context, info *dto.AuthorizationCodeInfo) (string, e
 	authURL := config.AuthCodeURL(encryptState)
 
 	return authURL, nil
+}
+
+func (p *pluginServiceImpl) generateOAuthNonce(ctx context.Context, userID string) (string, error) {
+	nonce := uuid.New().String()
+	key := oauthNonceKeyPrefix + nonce
+	ttl := oauthNonceTTL
+	err := p.oauthCache.Set(ctx, key, userID, &ttl)
+	if err != nil {
+		return "", fmt.Errorf("save oauth nonce failed, err=%v", err)
+	}
+	return nonce, nil
+}
+
+func (p *pluginServiceImpl) validateOAuthNonce(ctx context.Context, state *dto.OAuthState) error {
+	if state.Nonce == "" {
+		return errorx.New(errno.ErrPluginOAuthFailed, errorx.KV(errno.PluginMsgKey, "invalid or expired state"))
+	}
+
+	key := oauthNonceKeyPrefix + state.Nonce
+	storedUserID, exist, err := p.oauthCache.Get(ctx, key)
+	if err != nil {
+		return errorx.Wrapf(err, "get oauth nonce failed")
+	}
+	if !exist {
+		return errorx.New(errno.ErrPluginOAuthFailed, errorx.KV(errno.PluginMsgKey, "invalid or expired state"))
+	}
+	if storedUserID != state.UserID {
+		return errorx.New(errno.ErrPluginOAuthFailed, errorx.KV(errno.PluginMsgKey, "invalid state"))
+	}
+
+	_ = p.oauthCache.Del(ctx, key)
+	return nil
 }
 
 func getStanderOAuthConfig(ctx context.Context, authConfig *model.OAuthAuthorizationCodeConfig) (*oauth2.Config, error) {

--- a/backend/domain/plugin/service/service_impl.go
+++ b/backend/domain/plugin/service/service_impl.go
@@ -21,7 +21,9 @@ import (
 
 	"gorm.io/gorm"
 
+	"github.com/coze-dev/coze-studio/backend/domain/plugin/internal/dal"
 	"github.com/coze-dev/coze-studio/backend/domain/plugin/repository"
+	"github.com/coze-dev/coze-studio/backend/infra/cache"
 	"github.com/coze-dev/coze-studio/backend/infra/idgen"
 	"github.com/coze-dev/coze-studio/backend/infra/storage"
 	"github.com/coze-dev/coze-studio/backend/pkg/safego"
@@ -31,6 +33,7 @@ type Components struct {
 	IDGen      idgen.IDGenerator
 	DB         *gorm.DB
 	OSS        storage.Storage
+	CacheCli   cache.Cmdable
 	PluginRepo repository.PluginRepository
 	ToolRepo   repository.ToolRepository
 	OAuthRepo  repository.OAuthRepository
@@ -43,6 +46,7 @@ func NewService(components *Components) PluginService {
 		pluginRepo: components.PluginRepo,
 		toolRepo:   components.ToolRepo,
 		oauthRepo:  components.OAuthRepo,
+		oauthCache: dal.NewOAuthCache(components.CacheCli),
 	}
 
 	initOnce.Do(func() {
@@ -61,4 +65,5 @@ type pluginServiceImpl struct {
 	pluginRepo repository.PluginRepository
 	toolRepo   repository.ToolRepository
 	oauthRepo  repository.OAuthRepository
+	oauthCache *dal.OAuthCache
 }


### PR DESCRIPTION
The OAuth authorization code callback trusts the userID embedded in the encrypted state parameter without server-side verification, allowing an attacker to craft a state with a victim's userID and phish them into authorizing tokens bound to the wrong account.

Add a one-time nonce to the OAuth state, stored in Redis with a 10-minute TTL. On callback, verify the nonce exists and its associated userID matches the state before proceeding. The nonce is deleted after use to prevent replay.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
