### PR TITLE
fix(coderunner): handle null/true/false JSON literals in Python sandbox

### DIFF
--- a/backend/infra/coderunner/impl/script/sandbox.py
+++ b/backend/infra/coderunner/impl/script/sandbox.py
@@ -165,6 +165,9 @@ prefix = """\
 import json
 import sys
 import asyncio
+null = None
+true = True
+false = False
 class Args:
     def __init__(self, params):
         self.params = params


### PR DESCRIPTION
Fixes #2618

## Problem

When a workflow code node parameter has a `null` value, the Python sandbox crashes with:

```
NameError: name 'null' is not defined
```

**Root cause:** `json.dumps()` serializes `null`/`None` values as the JSON literal `null`, which is then embedded directly into generated Python code via string interpolation:

```python
code = prefix + f'args={json.dumps(params)}\n' + user_code + suffix
# produces: args={"input": "fdsa", "lists": null}
```

Python does not recognise `null`, `true`, or `false` as keywords — these are JSON literals but not Python identectives. Python uses `None`, `True`, and `False` instead.

## Solution

Add `null = None`, `true = True`, `false = False` aliases to the generated code prefix. This ensures that JSON-serialized parameter dicts evaluate correctly when the code string is executed by Pyodide:

```python
null = None
true = True
false = False
```

With these definitions in scope, the generated line `args={"input": "fdsa", "lists": null}` is valid Python and evaluates `null` as `None`.

## Testing

Manually verified that a code node with `{"input": "fdsa", "lists": null}` input no longer raises `NameError`. The aliases are defined before any user code runs, so they do not conflict with user-defined names in the `main()` function scope.