### PR TITLE
fix(workflow): handle 'number' DTO type in variable conversion

### DIFF
--- a/frontend/packages/workflow/base/src/types/dto.ts
+++ b/frontend/packages/workflow/base/src/types/dto.ts
@@ -197,6 +197,7 @@ export enum VariableTypeDTO {
   string = 'string',
   integer = 'integer',
   float = 'float',
+  number = 'number',
   boolean = 'boolean',
   image = 'image',
   time = 'time',

--- a/frontend/packages/workflow/variable/src/legacy/variable-utils.ts
+++ b/frontend/packages/workflow/variable/src/legacy/variable-utils.ts
@@ -92,6 +92,7 @@ export namespace variableUtils {
       case VariableTypeDTO.boolean:
         return ViewVariableType.Boolean;
       case VariableTypeDTO.float:
+      case VariableTypeDTO.number:
         return ViewVariableType.Number;
       case VariableTypeDTO.integer:
         return ViewVariableType.Integer;
@@ -120,6 +121,7 @@ export namespace variableUtils {
           case VariableTypeDTO.boolean:
             return ViewVariableType.ArrayBoolean;
           case VariableTypeDTO.float:
+          case VariableTypeDTO.number:
             return ViewVariableType.ArrayNumber;
           case VariableTypeDTO.integer:
             return ViewVariableType.ArrayInteger;

--- a/frontend/packages/workflow/variable/src/utils/generate-input-json-schema.ts
+++ b/frontend/packages/workflow/variable/src/utils/generate-input-json-schema.ts
@@ -34,6 +34,9 @@ const VariableType2JsonSchemaProps = {
   [VariableTypeDTO.float]: {
     type: 'number',
   },
+  [VariableTypeDTO.number]: {
+    type: 'number',
+  },
   [VariableTypeDTO.integer]: {
     type: 'integer',
   },


### PR DESCRIPTION
Fixes #2645

## Problem

When a plugin has output parameters with nested `array<number>` type (e.g., `array<object>[i].array<number>`), adding the plugin to a workflow throws:

```
Unknown variable DTO Type: list:number
```

The backend's `DataTypeNumber` (float64) is serialized as `"number"` in the API response, but `VariableTypeDTO` in `@coze-workflow/base` only defines `float` and `integer` for numeric types — `"number"` is unrecognized and falls through to the error branch in `DTOTypeToViewType`.

## Solution

- Add `number = 'number'` to the `VariableTypeDTO` enum in `dto.ts`
- In `DTOTypeToViewType`, treat `VariableTypeDTO.number` the same as `float` (both map to `ViewVariableType.Number` / `ViewVariableType.ArrayNumber`)
- Add `VariableTypeDTO.number` entry to the JSON Schema props map in `generate-input-json-schema.ts`

## Testing

The fix is minimal and localized to the DTO→view-type conversion layer. The `number` type is now treated identically to `float`, which matches the backend semantics (both represent float64).