### PR TITLE
docs(docker): improve .env.example inline docs and fix typos

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -29,9 +29,9 @@ export ALLOW_EMPTY_PASSWORD=yes
 export REDIS_ADDR="redis:6379"
 export REDIS_PASSWORD=""
 
-# This Upload component used in Agent / workflow File/Image With LLM  , support the component of imagex / storage
-# default: storage, use the settings of storage component
-# if imagex, you must finish the configuration of <VolcEngine ImageX>
+# This Upload component is used in Agent / Workflow File/Image with LLM; supported components are imagex / storage.
+# default: storage, uses the settings of the storage component below.
+# if imagex, you must complete the configuration of <VolcEngine ImageX>
 export FILE_UPLOAD_COMPONENT_TYPE="storage"
 
 # VolcEngine ImageX
@@ -46,7 +46,7 @@ export VE_IMAGEX_UPLOAD_HOST="https://imagex.volcengineapi.com"
 export STORAGE_TYPE="minio" # minio / tos / s3
 export STORAGE_UPLOAD_HTTP_SCHEME="http" # http / https. If coze studio website is https, you must set it to https
 export STORAGE_BUCKET="opencoze"
-# MiniIO
+# MinIO
 export MINIO_ROOT_USER=minioadmin
 export MINIO_ROOT_PASSWORD=minioadmin123
 export MINIO_DEFAULT_BUCKETS=milvus
@@ -259,16 +259,16 @@ export BUILTIN_CM_GEMINI_MODEL=""
 # The function of registration controller
 # If you want to disable the registration feature, set DISABLE_USER_REGISTRATION to true. You can then control allowed registrations via a whitelist with ALLOW_REGISTRATION_EMAIL.
 export DISABLE_USER_REGISTRATION="" # default "", if you want to disable, set to true
-export ALLOW_REGISTRATION_EMAIL=""  #  is a list of email addresses, separated by ",". Example: "11@example.com,22@example.com"
+export ALLOW_REGISTRATION_EMAIL=""  # a comma-separated list of allowed email addresses. Example: "11@example.com,22@example.com"
 
 # Plugin AES secret.
-# PLUGIN_AES_AUTH_SECRET is the secret of used to encrypt plugin authorization payload.
+# PLUGIN_AES_AUTH_SECRET is the secret used to encrypt plugin authorization payload.
 # The size of secret must be 16, 24 or 32 bytes.
 export PLUGIN_AES_AUTH_SECRET='^*6x3hdu2nc%-p38'
-# PLUGIN_AES_STATE_SECRET is the secret of used to encrypt oauth state.
+# PLUGIN_AES_STATE_SECRET is the secret used to encrypt oauth state.
 # The size of secret must be 16, 24 or 32 bytes.
 export PLUGIN_AES_STATE_SECRET='osj^kfhsd*(z!sno'
-# PLUGIN_AES_OAUTH_TOKEN_SECRET is the secret of used to encrypt oauth refresh token and access token.
+# PLUGIN_AES_OAUTH_TOKEN_SECRET is the secret used to encrypt oauth refresh token and access token.
 # The size of secret must be 16, 24 or 32 bytes.
 export PLUGIN_AES_OAUTH_TOKEN_SECRET='cn+$PJ(HhJ[5d*z9'
 

--- a/docker/atlas/README.md
+++ b/docker/atlas/README.md
@@ -1,4 +1,4 @@
-## 0. setup environment
+## 1. setup environment
 
 On Mac :
 
@@ -38,22 +38,22 @@ On developer machine（I want add/update table for my business）
 	  --dir "file://migrations" \
 	  --to $ATLAS_URL \
 	  --dev-url "docker://mysql/8/"
-	# will autogenerate some xxxxx_update.sql in margrations
+	# will autogenerate some xxxxx_update.sql in migrations
 	
 	
 	# Third, Check whether the contents of the new xxxx_update.sql file are correct.
 	# If any changes are needed, please modify it manually.
-	# If you manually modified margrations file, you need to run the following command to update its hash value.
-	# If you did not manually modify margrations file, do not run the following command.
+	# If you manually modified migrations file, you need to run the following command to update its hash value.
+	# If you did not manually modify migrations file, do not run the following command.
 	atlas migrate hash  # step 2 if need
 	atlas migrate status --url $ATLAS_URL --dir "file://migrations" # check status 
 	
-	# Last, dump the latest database schema for other developer
+	# Last, dump the latest database schema for other developers
 	atlas schema inspect -u $ATLAS_URL --exclude "atlas_schema_revisions,table_*"  > opencoze_latest_schema.hcl # step 3 
 
 ## 4. apply migration
 
-On developer machine（I want to update my local database with the changes that others developer have made）
+On developer machine（I want to update my local database with the changes that other developers have made）
 
 	# cd ./docker/atlas
 	atlas schema apply -u $ATLAS_URL --to file://opencoze_latest_schema.hcl # step 1 for developer on mac, this command will execute in start_debug.sh


### PR DESCRIPTION
#### What type of PR is this?

docs

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Add documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.

文档(docker)：改进 .env.example 内联注释并修复拼写错误

#### (Optional) More detailed description for this PR.

en:
Small documentation-only cleanup to reduce friction for new users running `docker compose up` for the first time. Many issues report Docker startup confusion; this PR makes the env example easier to read.

Changes (no behavioral changes — comments and docs only):

`docker/.env.example`
- Fix typo: `# MiniIO` → `# MinIO`
- Fix grammar: "is the secret of used to encrypt..." → "is the secret used to encrypt..." (3x for the PLUGIN_AES_*_SECRET vars)
- Tighten the `FILE_UPLOAD_COMPONENT_TYPE` block comment (capitalization, "support the component of" → "supported components are", "finish" → "complete")
- Fix dangling `ALLOW_REGISTRATION_EMAIL` comment that started with "  # is a list of email addresses" → "a comma-separated list of allowed email addresses"

`docker/atlas/README.md`
- Section heading "## 0. setup environment" → "## 1. setup environment" (matches the rest of the numbered sections 2/3/4)
- Fix typo "margrations" → "migrations" (3 occurrences)
- Fix grammar "for other developer" → "for other developers" and "others developer have made" → "other developers have made"

No `.env` defaults, secrets, ports, or `docker-compose.yml` logic were modified. Total diff: 14 insertions / 14 deletions across 2 files.

zh(optional):

#### (Optional) Which issue(s) this PR fixes:

