### PR TITLE
docs(pulsar): fix appendix numbering and broken ASP links

### DIFF
--- a/docs/pulsar-eventbus-integration-guide-en.md
+++ b/docs/pulsar-eventbus-integration-guide-en.md
@@ -292,7 +292,7 @@ For detailed cluster deployment configuration, please refer to the [Apache Pulsa
 
 For users who need a graphical interface to manage Pulsar clusters, consider using ASP Community Edition. ASP Community Edition is a modern management platform designed specifically for Apache Pulsar, providing an intuitive web interface to manage clusters, tenants, namespaces, topics, and other resources. The platform supports real-time monitoring, performance metrics display, configuration management, and other features that greatly simplify the daily operations of Pulsar clusters.
 
-For more information, please refer to: [ASP Community Edition Documentation](https://ascentstream.com/docs/asp/asp-community/overview)
+For more information, please refer to: [ASP Community Edition Documentation](https://ascentstream.com/products/asp)
 
 ### C. Integration Features
 
@@ -348,7 +348,7 @@ safego.Go(context.Background(), func() {
 })
 ```
 
-### C. Troubleshooting
+### D. Troubleshooting
 
 #### 1. Common Issues
 
@@ -410,7 +410,7 @@ curl http://localhost:8080/admin/v2/persistent/public/default/your-topic/stats
 docker exec -it coze-pulsar bin/pulsar-admin topics subscriptions persistent://public/default/your-topic
 ```
 
-### D. Best Practices
+### E. Best Practices
 
 #### 1. Production Environment Configuration
 
@@ -466,5 +466,5 @@ Through this integration, Coze Studio provides users with a high-performance, hi
 
 - [Apache Pulsar Official Documentation](https://pulsar.apache.org/docs/)
 - [Pulsar Go Client Documentation](https://pulsar.apache.org/docs/client-libraries-go/)
-- [ASP Community Edition Documentation](https://ascentstream.com/docs/asp/asp-community/overview)
+- [ASP Community Edition Documentation](https://ascentstream.com/products/asp)
 - [Coze Studio Project Repository](https://github.com/coze-dev/coze-studio)

--- a/docs/pulsar-eventbus-integration-guide.md
+++ b/docs/pulsar-eventbus-integration-guide.md
@@ -233,7 +233,7 @@ docker exec -it coze-pulsar bin/pulsar-admin clusters list
 
 对于需要图形化界面管理 Pulsar 集群的用户，可以考虑使用 ASP 社区版。ASP 社区版是一个专为 Apache Pulsar 设计的现代化管理平台，提供了直观的 Web 界面来管理集群、租户、命名空间、主题等资源。该平台支持实时监控、性能指标展示、配置管理等功能，大大简化了 Pulsar 集群的日常运维工作。
 
-更多信息请参考：[ASP 社区版文档](https://ascentstream.com/docs/asp/asp-community/overview)
+更多信息请参考：[ASP 社区版文档](https://ascentstream.com/products/asp)
 
 ### C. 适配特点
 
@@ -289,7 +289,7 @@ safego.Go(context.Background(), func() {
 })
 ```
 
-### C. 故障排查
+### D. 故障排查
 
 #### 1. 常见问题
 
@@ -351,7 +351,7 @@ curl http://localhost:8080/admin/v2/persistent/public/default/your-topic/stats
 docker exec -it coze-pulsar bin/pulsar-admin topics subscriptions persistent://public/default/your-topic
 ```
 
-### D. 最佳实践
+### E. 最佳实践
 
 #### 1. 生产环境配置
 
@@ -407,5 +407,5 @@ Apache Pulsar 在 Coze Studio 中的 EventBus 集成实现了以下目标：
 
 - [Apache Pulsar 官方文档](https://pulsar.apache.org/docs/)
 - [Pulsar Go Client 文档](https://pulsar.apache.org/docs/client-libraries-go/)
-- [ASP 社区版文档](https://ascentstream.com/docs/asp/asp-community/overview)
+- [ASP 社区版文档](https://ascentstream.com/products/asp)
 - [Coze Studio 项目地址](https://github.com/coze-dev/coze-studio)


### PR DESCRIPTION
#### What type of PR is this?

docs: Documentation only changes

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Add documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.

docs(pulsar): 修复附录编号与失效的 ASP 文档链接

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:
Mechanical fixes to the Pulsar EventBus integration guide (both EN and ZH versions):

- Re-letter appendix headings so numbering is sequential:
  - `### C. Troubleshooting` → `### D. Troubleshooting` (and ZH equivalent)
  - `### D. Best Practices` → `### E. Best Practices` (and ZH equivalent)
- Replace 4 broken ASP Community Edition documentation links:
  - Old: `https://ascentstream.com/docs/asp/asp-community/overview` (404)
  - New: `https://ascentstream.com/products/asp`

Files changed:
- `docs/pulsar-eventbus-integration-guide-en.md`
- `docs/pulsar-eventbus-integration-guide.md`

zh(optional):
对 Pulsar EventBus 集成指南（中英双语）进行机械性修复：修正附录小节字母编号的连续性，并替换 4 处失效的 ASP 社区版文档链接为可访问的产品页地址。

#### (Optional) Which issue(s) this PR fixes:
