### PR TITLE
style: correct typos in Go comments and log/error messages

### DIFF
--- a/backend/application/conversation/openapi_agent_run.go
+++ b/backend/application/conversation/openapi_agent_run.go
@@ -378,7 +378,7 @@ func (a *OpenapiAgentRunApplication) pullStream(ctx context.Context, sseSender *
 			sseSender.Send(ctx, buildMessageChunkEvent(string(chunk.Event), buildARSM2ApiMessage(chunk)))
 
 		default:
-			logs.CtxErrorf(ctx, "unknow handler event:%v", chunk.Event)
+			logs.CtxErrorf(ctx, "unknown handler event:%v", chunk.Event)
 		}
 	}
 }

--- a/backend/application/workflow/chatflow.go
+++ b/backend/application/workflow/chatflow.go
@@ -818,7 +818,7 @@ func (w *ApplicationService) convertToChatFlowRunResponseList(ctx context.Contex
 				if intermediateMessage != nil {
 					_, mErr := crossmessage.DefaultSVC().Create(ctx, intermediateMessage)
 					if mErr != nil {
-						logs.CtxWarnf(ctx, "create message faield, err: %v", err)
+						logs.CtxWarnf(ctx, "create message failed, err: %v", err)
 					}
 				}
 			}

--- a/backend/domain/workflow/internal/nodes/convert.go
+++ b/backend/domain/workflow/internal/nodes/convert.go
@@ -443,7 +443,7 @@ func convertToArray(ctx context.Context, in any, path string, t *vo.TypeInfo, op
 		if err != nil {
 			return nil, nil, err
 		} else if ws != nil {
-			if elemType.Type == vo.DataTypeObject { // If the array type and the element is an object, the converted object will also need to be added to the array when waring occurs
+			if elemType.Type == vo.DataTypeObject { // If the array type and the element is an object, the converted object will also need to be added to the array when warning occurs
 				out = append(out, newV)
 			}
 			warnings = append(warnings, *ws...)

--- a/backend/domain/workflow/internal/nodes/database/common.go
+++ b/backend/domain/workflow/internal/nodes/database/common.go
@@ -213,7 +213,7 @@ func formatted(in any, ty *vo.TypeInfo) any {
 			for _, in := range arrayIn {
 				r, err := toInteger(in)
 				if err != nil {
-					logs.Warnf("formatted interger failed: %v", err)
+					logs.Warnf("formatted integer failed: %v", err)
 					continue
 				}
 				result = append(result, r)

--- a/backend/domain/workflow/internal/nodes/httprequester/http_requester.go
+++ b/backend/domain/workflow/internal/nodes/httprequester/http_requester.go
@@ -195,7 +195,7 @@ type Config struct {
 func (c *Config) Adapt(_ context.Context, n *vo.Node, opts ...nodes.AdaptOption) (*schema.NodeSchema, error) {
 	options := nodes.GetAdaptOptions(opts...)
 	if options.Canvas == nil {
-		return nil, fmt.Errorf("canvas is requried when adapting HTTPRequester node")
+		return nil, fmt.Errorf("canvas is required when adapting HTTPRequester node")
 	}
 
 	implicitDeps, err := extractImplicitDependency(n, options.Canvas)
@@ -329,7 +329,7 @@ func convertLocation(l string) (Location, error) {
 
 func (c *Config) Build(_ context.Context, _ *schema.NodeSchema, _ ...schema.BuildOption) (any, error) {
 	if len(c.Method) == 0 {
-		return nil, fmt.Errorf("method is requried")
+		return nil, fmt.Errorf("method is required")
 	}
 
 	hg := &HTTPRequester{


### PR DESCRIPTION
#### What type of PR is this?
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)

#### Check the PR title.
- [x] This PR title matches the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Add documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.
样式: 修正 Go 注释及日志/错误信息中的拼写错误

#### (Optional) More detailed description for this PR (en: English / zh: Chinese).
en: This PR fixes a handful of minor spelling typos found in Go comments and log/error message strings under `backend/`. There are no functional or behavioral changes — all edits are confined to comments and human-readable log/error strings. Concretely:

- `backend/application/conversation/openapi_agent_run.go`: `unknow handler event` → `unknown handler event`
- `backend/application/workflow/chatflow.go`: `create message faield` → `create message failed`
- `backend/domain/workflow/internal/nodes/convert.go`: comment `when waring occurs` → `when warning occurs`
- `backend/domain/workflow/internal/nodes/database/common.go`: `formatted interger failed` → `formatted integer failed`
- `backend/domain/workflow/internal/nodes/httprequester/http_requester.go`: two occurrences of `requried` → `required` in error messages

zh(optional): 本次 PR 修复了 `backend/` 目录下若干 Go 注释及日志/错误信息字符串中的拼写错误，未涉及任何功能或行为变更。

#### (Optional) Which issue(s) this PR fixes:
None.
