### PR TITLE
fix(knowledge): avoid panic on empty table raw content

### DIFF
--- a/backend/domain/knowledge/service/event_handle.go
+++ b/backend/domain/knowledge/service/event_handle.go
@@ -752,6 +752,15 @@ func packInsertData(slices []*entity.Slice) (data []map[string]interface{}, err 
 	}()
 
 	for i := range slices {
+		if len(slices[i].RawContent) == 0 {
+			return nil, errorx.New(errno.ErrKnowledgeParseResultEmptyCode,
+				errorx.KV("msg", fmt.Sprintf("slice %d raw content is empty", slices[i].ID)))
+		}
+		if slices[i].RawContent[0] == nil || slices[i].RawContent[0].Type != knowledge.SliceContentTypeTable || slices[i].RawContent[0].Table == nil {
+			return nil, errorx.New(errno.ErrKnowledgeInvalidParamCode,
+				errorx.KV("msg", fmt.Sprintf("slice %d table raw content is invalid", slices[i].ID)))
+		}
+
 		dataMap := map[string]any{
 			consts.RDBFieldID: slices[i].ID,
 		}

--- a/backend/domain/knowledge/service/event_handle_test.go
+++ b/backend/domain/knowledge/service/event_handle_test.go
@@ -19,13 +19,19 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	. "github.com/bytedance/mockey"
 	"github.com/smartystreets/goconvey/convey"
 
+	knowledgeModel "github.com/coze-dev/coze-studio/backend/crossdomain/knowledge/model"
 	"github.com/coze-dev/coze-studio/backend/domain/knowledge/entity"
+	"github.com/coze-dev/coze-studio/backend/domain/knowledge/internal/consts"
+	"github.com/coze-dev/coze-studio/backend/infra/document"
 	"github.com/coze-dev/coze-studio/backend/infra/eventbus"
+	"github.com/coze-dev/coze-studio/backend/pkg/errorx"
+	"github.com/coze-dev/coze-studio/backend/types/errno"
 )
 
 func TestEventHandle(t *testing.T) {
@@ -43,3 +49,61 @@ func TestEventHandle(t *testing.T) {
 		})
 	})
 }
+
+func TestPackInsertData(t *testing.T) {
+	PatchConvey("test packInsertData", t, func() {
+		PatchConvey("should return parse result empty error when raw content is empty", func() {
+			data, err := packInsertData([]*entity.Slice{{
+				Info: knowledgeModel.Info{ID: 123},
+			}})
+
+			convey.So(data, convey.ShouldBeNil)
+			convey.So(err, convey.ShouldNotBeNil)
+			var statusErr errorx.StatusError
+			convey.So(errors.As(err, &statusErr), convey.ShouldBeTrue)
+			convey.So(statusErr.Code(), convey.ShouldEqual, errno.ErrKnowledgeParseResultEmptyCode)
+			convey.So(err.Error(), convey.ShouldContainSubstring, "slice 123 raw content is empty")
+		})
+
+		PatchConvey("should return invalid param error when table raw content is invalid", func() {
+			data, err := packInsertData([]*entity.Slice{{
+				Info: knowledgeModel.Info{ID: 456},
+				RawContent: []*knowledgeModel.SliceContent{{
+					Type: knowledgeModel.SliceContentTypeText,
+				}},
+			}})
+
+			convey.So(data, convey.ShouldBeNil)
+			convey.So(err, convey.ShouldNotBeNil)
+			var statusErr errorx.StatusError
+			convey.So(errors.As(err, &statusErr), convey.ShouldBeTrue)
+			convey.So(statusErr.Code(), convey.ShouldEqual, errno.ErrKnowledgeInvalidParamCode)
+			convey.So(err.Error(), convey.ShouldContainSubstring, "slice 456 table raw content is invalid")
+		})
+
+		PatchConvey("should pack valid table rows without primary key column", func() {
+			data, err := packInsertData([]*entity.Slice{{
+				Info: knowledgeModel.Info{ID: 789},
+				RawContent: []*knowledgeModel.SliceContent{{
+					Type: knowledgeModel.SliceContentTypeTable,
+					Table: &knowledgeModel.SliceTable{Columns: []*document.ColumnData{
+						{ColumnID: 1001, ColumnName: "name", Type: document.TableColumnTypeString, ValString: stringPtr("alice")},
+						{ColumnID: 1002, ColumnName: "age", Type: document.TableColumnTypeInteger, ValInteger: int64Ptr(18)},
+						{ColumnID: 1003, ColumnName: "id", Type: document.TableColumnTypeInteger, ValInteger: int64Ptr(999)},
+					}},
+				}},
+			}})
+
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(len(data), convey.ShouldEqual, 1)
+			convey.So(data[0][consts.RDBFieldID], convey.ShouldEqual, int64(789))
+			convey.So(*(data[0]["c_1001"].(*string)), convey.ShouldEqual, "alice")
+			convey.So(*(data[0]["c_1002"].(*int64)), convey.ShouldEqual, int64(18))
+			convey.So(*(data[0]["c_1003"].(*int64)), convey.ShouldEqual, int64(999))
+		})
+	})
+}
+
+func stringPtr(v string) *string { return &v }
+
+func int64Ptr(v int64) *int64 { return &v }


### PR DESCRIPTION
## Problem
- uploading or editing some knowledge-base table content could fail with `code=105000005` and panic on `index out of range [0] with length 0`
- root cause: `packInsertData` accessed `slice.RawContent[0]` without validating that `RawContent` existed and contained a valid table payload

## Fix
- guard against empty `RawContent`
- guard against nil/non-table/empty table payload before dereferencing index 0
- return typed business errors instead of panicking so the caller can fail gracefully
- add focused tests covering empty payload, invalid payload, and valid table rows

## Test
- `PATH=/home/clawos/work/.local-go/go/bin:$PATH GOPATH=/home/clawos/work/.gopath GOCACHE=/home/clawos/work/.gocache GOMODCACHE=/home/clawos/work/.gomodcache GOPROXY=https://proxy.golang.org,direct GOSUMDB=sum.golang.org GOFLAGS='-buildvcs=false -p=1' /home/clawos/work/.local-go/go/bin/go test -gcflags='all=-N -l' ./domain/knowledge/service -run 'Test(EventHandle|PackInsertData)' -count=1 -v`
