### PR TITLE
fix: wrong error variable in copy log, remove debug fmt.Println calls

### DIFF
--- a/backend/domain/knowledge/service/datacopy.go
+++ b/backend/domain/knowledge/service/datacopy.go
@@ -270,7 +270,7 @@ func (k *knowledgeSVC) copyKnowledgeDocuments(ctx context.Context, copyCtx *know
 				mu.Lock()
 				failList = append(failList, doc.ID)
 				mu.Unlock()
-				logs.CtxErrorf(ctx, "copy document failed, src document id: %d, new id: %d, err: %v", doc.ID, newID, err)
+				logs.CtxErrorf(ctx, "copy document failed, src document id: %d, new id: %d, err: %v", doc.ID, newID, cpErr)
 				return cpErr
 			}
 			return nil

--- a/backend/domain/workflow/internal/nodes/batch/batch.go
+++ b/backend/domain/workflow/internal/nodes/batch/batch.go
@@ -348,7 +348,6 @@ func (b *Batch) Invoke(ctx context.Context, in map[string]any, opts ...nodes.Nod
 			stateModifier, ok := options.GetResumeIndexes()[i]
 			mu.Unlock()
 			if ok {
-				fmt.Println("has state modifier for ith run: ", i, ", checkpointID: ", subCheckpointID)
 				ithOpts = append(ithOpts, compose.WithStateModifier(stateModifier))
 			}
 		} else {
@@ -456,7 +455,6 @@ func (b *Batch) Invoke(ctx context.Context, in map[string]any, opts ...nodes.Nod
 			return nil, err
 		}
 
-		fmt.Println("save composite info in state within batch: ", compState)
 	}
 
 	if existingCState != nil && len(existingCState.Index2InterruptInfo) > 0 {

--- a/backend/domain/workflow/internal/nodes/loop/loop.go
+++ b/backend/domain/workflow/internal/nodes/loop/loop.go
@@ -379,7 +379,6 @@ func (l *Loop) Invoke(ctx context.Context, in map[string]any, opts ...nodes.Node
 		if len(options.GetResumeIndexes()) > 0 {
 			stateModifier, ok := options.GetResumeIndexes()[i]
 			if ok {
-				fmt.Println("has state modifier for ith run: ", i, ", checkpointID: ", checkpointID)
 				ithOpts = append(ithOpts, compose.WithStateModifier(stateModifier))
 			}
 		}
@@ -451,7 +450,6 @@ func (l *Loop) Invoke(ctx context.Context, in map[string]any, opts ...nodes.Node
 			return nil, err
 		}
 
-		fmt.Println("save composite info in state within loop: ", compState)
 	}
 
 	if existingCState != nil && len(existingCState.Index2InterruptInfo) > 0 {


### PR DESCRIPTION
Two issues:

- \`datacopy.go\` line 273 was logging \`err\` instead of \`cpErr\` when a document copy failed. At that point \`err\` was nil from a previous successful call, so every copy failure logged \`err: <nil>\` making it impossible to debug copy issues in production.

- \`loop.go\` and \`batch.go\` had \`fmt.Println\` debug statements left in production code. These bypass the structured logging system (\`logs.CtxInfof\`), can't be filtered by log level, and leak internal state info to stdout.