### PR TITLE
fix(workflow): prevent nil pointer dereference when merging batch inner node executions

### DIFF
--- a/backend/domain/workflow/service/executable_impl.go
+++ b/backend/domain/workflow/service/executable_impl.go
@@ -737,6 +737,13 @@ func (i *impl) GetLatestNodeDebugInput(ctx context.Context, wfID int64, nodeID s
 }
 
 func mergeCompositeInnerNodes(nodeExes map[int]*entity.NodeExecution, maxIndex int) *entity.NodeExecution {
+	if len(nodeExes) == 0 {
+		// no inner node executions to merge, e.g. node debugging a batch mode node
+		// whose input list is empty or whose inner executions are not persisted yet.
+		// returning early avoids a nil pointer dereference below.
+		return nil
+	}
+
 	var groupNodeExe *entity.NodeExecution
 	for _, v := range nodeExes {
 		groupNodeExe = &entity.NodeExecution{

--- a/backend/domain/workflow/service/executable_impl_test.go
+++ b/backend/domain/workflow/service/executable_impl_test.go
@@ -29,6 +29,7 @@ import (
 	messagemock "github.com/coze-dev/coze-studio/backend/crossdomain/message/messagemock"
 	workflowModel "github.com/coze-dev/coze-studio/backend/crossdomain/workflow/model"
 	"github.com/coze-dev/coze-studio/backend/domain/workflow/entity"
+	"github.com/coze-dev/coze-studio/backend/domain/workflow/entity/vo"
 	mock_workflow "github.com/coze-dev/coze-studio/backend/internal/mock/domain/workflow"
 	"github.com/coze-dev/coze-studio/backend/pkg/lang/ptr"
 )
@@ -280,6 +281,150 @@ func TestImpl_prefetchChatHistory(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestImpl_GetNodeExecution(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		exeID  = int64(1001)
+		nodeID = "n1"
+	)
+
+	tests := []struct {
+		name        string
+		setupMock   func(repo *mock_workflow.MockRepository)
+		expectErr   bool
+		expectNode  bool
+		expectInner bool
+		innerNodeID string
+	}{
+		{
+			name: "node execution not found returns error",
+			setupMock: func(repo *mock_workflow.MockRepository) {
+				repo.EXPECT().GetNodeExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, false, nil).AnyTimes()
+			},
+			expectErr: true,
+		},
+		{
+			name: "non batch node returns node execution directly",
+			setupMock: func(repo *mock_workflow.MockRepository) {
+				repo.EXPECT().GetNodeExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&entity.NodeExecution{NodeID: nodeID, NodeType: entity.NodeTypeLLM}, true, nil).AnyTimes()
+			},
+			expectNode:  true,
+			expectInner: false,
+		},
+		{
+			name: "batch node not in node debug mode returns node execution directly",
+			setupMock: func(repo *mock_workflow.MockRepository) {
+				repo.EXPECT().GetNodeExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&entity.NodeExecution{NodeID: nodeID, NodeType: entity.NodeTypeBatch}, true, nil).AnyTimes()
+				repo.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&entity.WorkflowExecution{
+						ExecuteConfig: workflowModel.ExecuteConfig{Mode: workflowModel.ExecuteModeDebug},
+					}, true, nil).AnyTimes()
+			},
+			expectNode:  true,
+			expectInner: false,
+		},
+		{
+			// Regression test: a batch mode node debugged with no persisted inner
+			// executions used to build an empty index2Exe map and pass it to
+			// mergeCompositeInnerNodes, causing a nil pointer dereference panic.
+			name: "batch node in node debug mode with no inner executions does not panic",
+			setupMock: func(repo *mock_workflow.MockRepository) {
+				repo.EXPECT().GetNodeExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&entity.NodeExecution{NodeID: nodeID, NodeType: entity.NodeTypeBatch}, true, nil).AnyTimes()
+				repo.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&entity.WorkflowExecution{
+						ExecuteConfig: workflowModel.ExecuteConfig{Mode: workflowModel.ExecuteModeNodeDebug},
+					}, true, nil).AnyTimes()
+				repo.EXPECT().GetNodeExecutionByParent(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return([]*entity.NodeExecution{}, nil).AnyTimes()
+			},
+			expectNode:  true,
+			expectInner: false,
+		},
+		{
+			name: "batch mode node merges generated inner executions",
+			setupMock: func(repo *mock_workflow.MockRepository) {
+				repo.EXPECT().GetNodeExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&entity.NodeExecution{NodeID: nodeID, NodeType: entity.NodeTypeBatch}, true, nil).AnyTimes()
+				repo.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&entity.WorkflowExecution{
+						ExecuteConfig: workflowModel.ExecuteConfig{Mode: workflowModel.ExecuteModeNodeDebug},
+					}, true, nil).AnyTimes()
+				repo.EXPECT().GetNodeExecutionByParent(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return([]*entity.NodeExecution{
+						{
+							ExecuteID: exeID,
+							NodeID:    vo.GenerateNodeIDForBatchMode(nodeID),
+							NodeType:  entity.NodeTypeLLM,
+							Index:     0,
+							Status:    entity.NodeSuccess,
+						},
+					}, nil).AnyTimes()
+			},
+			expectNode:  true,
+			expectInner: true,
+			innerNodeID: vo.GenerateNodeIDForBatchMode(nodeID),
+		},
+		{
+			name: "normal batch node with non generated inner nodes returns node execution directly",
+			setupMock: func(repo *mock_workflow.MockRepository) {
+				repo.EXPECT().GetNodeExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&entity.NodeExecution{NodeID: nodeID, NodeType: entity.NodeTypeBatch}, true, nil).AnyTimes()
+				repo.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&entity.WorkflowExecution{
+						ExecuteConfig: workflowModel.ExecuteConfig{Mode: workflowModel.ExecuteModeNodeDebug},
+					}, true, nil).AnyTimes()
+				repo.EXPECT().GetNodeExecutionByParent(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return([]*entity.NodeExecution{
+						{
+							ExecuteID: exeID,
+							NodeID:    "child_node",
+							NodeType:  entity.NodeTypeLLM,
+							Index:     0,
+							Status:    entity.NodeSuccess,
+						},
+					}, nil).AnyTimes()
+			},
+			expectNode:  true,
+			expectInner: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockRepo := mock_workflow.NewMockRepository(ctrl)
+			tt.setupMock(mockRepo)
+
+			testImpl := &impl{repo: mockRepo}
+
+			nodeExe, innerExe, err := testImpl.GetNodeExecution(ctx, exeID, nodeID)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			if tt.expectNode {
+				assert.NotNil(t, nodeExe)
+			}
+			if tt.expectInner {
+				assert.NotNil(t, innerExe)
+				assert.Equal(t, tt.innerNodeID, innerExe.NodeID)
+			} else {
+				assert.Nil(t, innerExe)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it

`mergeCompositeInnerNodes` (in `backend/domain/workflow/service/executable_impl.go`)
builds its result by iterating the `nodeExes` map to seed a `groupNodeExe`
pointer, then unconditionally writes to it:

```go
var groupNodeExe *entity.NodeExecution
for _, v := range nodeExes {
    groupNodeExe = &entity.NodeExecution{ ... }
    break
}
...
groupNodeExe.IndexedExecutions = make([]*entity.NodeExecution, maxIndex+1) // nil deref if nodeExes is empty
```

When `nodeExes` is empty, `groupNodeExe` stays `nil` and the subsequent write
panics with a nil pointer dereference.

This path is reachable from `GetNodeExecution`. When a node running in **batch
mode** (e.g. an LLM node with batch enabled, which is compiled into a
`NodeTypeBatch` parent + a generated `<id>_inner` node) is node-debugged, the
function queries the inner executions via `GetNodeExecutionByParent`. If that
returns an empty slice — for example the batch iterated over an empty input
list, or the inner executions have not been persisted yet — the loop that
checks `IsGeneratedNodeForBatchMode` does not run, `index2Exe` is left empty,
and `mergeCompositeInnerNodes(index2Exe, 0)` is called with an empty map,
triggering the panic in the request goroutine.

The fix returns early (`nil`) when there are no inner executions to merge.
`GetNodeExecution` then returns `(nodeExe, nil, nil)`, which is consistent with
the other early-return branches of the function (a `nil` inner execution is
already an expected value for callers such as `GetLatestNodeDebugInput`). The
other caller, `GetExecution`, only ever passes non-empty maps, so its behavior
is unchanged.

#### Which issue(s) this PR fixes

Related to #2684 (behavior of `GetNodeExecution` for batch / batch-mode nodes).

#### Test plan

Adds `TestImpl_GetNodeExecution` covering:
- node execution not found -> error
- non-batch node -> returns node execution directly
- batch node not in node-debug mode -> returns node execution directly
- batch node in node-debug mode with **no inner executions** -> no panic (regression)
- batch-mode node with generated inner executions -> merged inner execution returned
- normal batch node with non-generated inner nodes -> returns node execution directly

The tests follow the existing table-driven `gomock` style in
`executable_impl_test.go`.

Note: verified by reading types/signatures and tracing the code paths; the Go
build and tests were not executed in my environment.
