### PR TITLE
fix(workflow): allow cross-type numeric comparison in selector operator WillAccept

### DIFF
--- a/backend/domain/workflow/internal/nodes/selector/operator.go
+++ b/backend/domain/workflow/internal/nodes/selector/operator.go
@@ -57,7 +57,7 @@ func (o *Operator) WillAccept(leftT, rightT reflect.Type) error {
 			return fmt.Errorf("operator %v only accepts int64, float64, bool or string, not %v", *o, leftT)
 		}
 
-		if leftT.Kind() == reflect.Bool || leftT.Kind() != reflect.String {
+		if leftT.Kind() == reflect.Bool {
 			if leftT != rightT {
 				return fmt.Errorf("operator %v left operant and right operant must be same type: %v, %v", *o, leftT, rightT)
 			}


### PR DESCRIPTION
## Problem

The `WillAccept` method in `backend/domain/workflow/internal/nodes/selector/operator.go` has an overly restrictive type check for `OperatorEqual` and `OperatorNotEqual`. The condition at line 60:

```go
if leftT.Kind() == reflect.Bool || leftT.Kind() != reflect.String {
```

This enforces strict type equality (`leftT == rightT`) for **all** non-string types, including `int64` and `float64`. However, the runtime evaluation in `Clause.Resolve()` (clause.go) uses `alignNumberTypes()` to transparently handle int64-vs-float64 comparisons. The subsequent check at lines 66-70 also explicitly validates cross-numeric operands.

**Impact**: Comparing `int64` with `float64` (e.g., `1 == 1.0`) is rejected by `WillAccept` with "left operant and right operant must be same type", even though the runtime correctly handles it. This prevents valid selector conditions from being validated.

## Fix

Change line 60 to only enforce strict type equality for booleans:

```go
if leftT.Kind() == reflect.Bool {
```

This is correct because:
- **Bool**: must match bool (strict equality)
- **String**: flexible, non-string types can be compared via string conversion
- **Int64/Float64**: cross-type check is already handled by the dedicated numeric validation at lines 66-70, which ensures rightT is int64 or float64

## Verification

- Traced all code paths through `WillAccept` (operator.go) and `Resolve` (clause.go) to confirm the fix does not introduce any regressions
- Existing `operator_test.go` tests all continue to pass logically (no test case covers int64-vs-float64, confirming the gap)
- Single-line change, no new imports or API surface changes
- **Verified by reading; not compiled/executed**

Signed-off-by: nankingjing <nankingjing@users.noreply.github.com>