### PR TITLE
fix(plugin): prevent nil pointer dereference when validating manifest without auth

### DIFF
--- a/backend/crossdomain/plugin/model/plugin_manifest.go
+++ b/backend/crossdomain/plugin/model/plugin_manifest.go
@@ -117,6 +117,10 @@ func (mf *PluginManifest) Validate(skipAuthPayload bool) (err error) {
 		return errorx.New(errno.ErrPluginInvalidManifest, errorx.KVf(errno.PluginMsgKey,
 			"invalid api type '%s'", mf.API.Type))
 	}
+	if mf.Auth == nil {
+		return errorx.New(errno.ErrPluginInvalidManifest, errorx.KV(errno.PluginMsgKey,
+			"auth is required"))
+	}
 	// auth.type=none,return nil
 	if mf.Auth.Type == consts.AuthzTypeOfNone {
 		return nil


### PR DESCRIPTION
### Summary
`PluginManifest.Validate` dereferences `mf.Auth.Type` before any nil check on `mf.Auth`, so a manifest whose JSON omits the `auth` field (or sets it to `null`) causes a nil pointer dereference (panic) instead of a validation error.

### Root cause
`Auth` is a nilable pointer field (`Auth *AuthV2`). Two other methods in the same file already guard it:
- `EncryptAuthPayload` returns early on `mf == nil || mf.Auth == nil`.
- `validateAuthInfo` returns an `"auth is required"` validation error when `mf.Auth == nil`.

However, `Validate` reaches `if mf.Auth.Type == consts.AuthzTypeOfNone` (the `auth.type == none` short-circuit) before it ever calls `validateAuthInfo`, so that existing nil guard is dead code for the "auth omitted" path.

### Trigger
`PluginApplicationService.RegisterPlugin` unmarshals the caller-supplied `ai_plugin` JSON straight into the manifest and then calls `CreateDraftPluginWithCode` -> `Manifest.Validate(false)`:
- `backend/application/plugin/registration.go`: `sonic.UnmarshalString(req.AiPlugin, &mf)` (only `LogoURL` is set afterwards)
- `backend/domain/plugin/service/plugin_draft.go`: `req.Manifest.Validate(false)`

A manifest that sets `schema_version`, the name/description fields and a valid `api.type` but has no `auth` key passes every check up to the `mf.Auth.Type` access and then panics. The same path is reachable via `UpdateDraftPluginWithCode` and the startup config loader (`Validate(true)`).

### Fix
Add a nil check for `mf.Auth` before the `auth.type == none` short-circuit, returning the same `"auth is required"` error that `validateAuthInfo` already returns for a nil `Auth`. This turns the panic into the intended validation error and preserves existing behavior for every non-nil case.

### Verification
Verified by reading and tracing the call path; not executed (no Go toolchain was available in my environment). The change is a small guard that reuses the `errorx`/`errno` symbols already imported and used in this file.