### PR TITLE
fix(user): propagate DB error in CheckEmailExist before existence check

### DIFF
--- a/backend/domain/user/internal/dal/user.go
+++ b/backend/domain/user/internal/dal/user.go
@@ -123,12 +123,12 @@ func (dao *UserDAO) UpdateProfile(ctx context.Context, userID int64, updates map
 
 func (dao *UserDAO) CheckEmailExist(ctx context.Context, email string) (bool, error) {
 	_, exist, err := dao.GetUsersByEmail(ctx, email)
-	if !exist {
-		return false, nil
-	}
-
 	if err != nil {
 		return false, err
+	}
+
+	if !exist {
+		return false, nil
 	}
 
 	return true, nil


### PR DESCRIPTION
## Problem

`backend/domain/user/internal/dal/user.go` line 124, `UserDAO.CheckEmailExist` has a reversed check order that swallows real DB errors.

```go
func (dao *UserDAO) CheckEmailExist(ctx context.Context, email string) (bool, error) {
	_, exist, err := dao.GetUsersByEmail(ctx, email)
	if !exist {
		return false, nil   // returns first, even when err != nil
	}
	if err != nil {
		return false, err   // dead code when exist == false
	}
	return true, nil
}
```

`GetUsersByEmail` returns three cases:

| case | return |
|------|--------|
| record not found | `(nil, false, nil)` |
| **real DB error** | `(nil, false, err)` |
| found | `(user, true, nil)` |

On a **real DB error** it returns `exist=false` **and** `err != nil`. Because `CheckEmailExist` checks `!exist` first, it returns `(false, nil)` and never reaches the `if err != nil` branch, so that branch is dead code. The transient DB error is silently swallowed and reported as "email does not exist".

## External consequence

`userImpl.Create` (`backend/domain/user/service/user_impl.go`, the signup path) does:

```go
exist, err := u.UserRepo.CheckEmailExist(ctx, req.Email)
if err != nil {
	return nil, err
}
if exist {
	return nil, errorx.New(errno.ErrUserEmailAlreadyExistCode, ...)
}
// ... otherwise proceeds to create the user
```

When the existence query hits a transient DB error, `CheckEmailExist` returns `(false, nil)`, so `Create` treats the email as free and proceeds to CreateUser instead of aborting with the error. This masks the failure and leads to a wrong signup outcome (duplicate-account attempt / unique-constraint failure on insert) instead of a clean, retryable error.

## Fix

Return the error before the existence check, so real DB errors propagate while the not-found and found cases keep their exact prior behavior:

```go
_, exist, err := dao.GetUsersByEmail(ctx, email)
if err != nil {
	return false, err
}
if !exist {
	return false, nil
}
return true, nil
```

Behavior table (unchanged for correct cases, fixed for the error case):

| case | before | after |
|------|--------|-------|
| not found | `(false, nil)` | `(false, nil)` |
| DB error | `(false, nil)` swallowed | `(false, err)` propagated |
| found | `(true, nil)` | `(true, nil)` |

The `(bool, error)` contract is preserved. Minimal, focused diff (statement reorder only).

## Verification

No Go toolchain in the environment (`go: command not found`), so verified by reading and tracing the two functions and the caller; **not executed**.
