### PR TITLE
fix(parser): return real error from csvIterator.NextRow instead of nil

### DIFF
--- a/backend/infra/document/parser/impl/builtin/parse_csv.go
+++ b/backend/infra/document/parser/impl/builtin/parse_csv.go
@@ -46,7 +46,7 @@ func (c *csvIterator) NextRow() (row []string, end bool, err error) {
 		if errors.Is(e, io.EOF) {
 			return nil, true, nil
 		}
-		return nil, false, err
+		return nil, false, e
 	}
 
 	return row, false, nil


### PR DESCRIPTION
### What

`csvIterator.NextRow` returns a nil error on genuine (non-EOF) CSV read failures, so parse errors are silently swallowed.

`backend/infra/document/parser/impl/builtin/parse_csv.go`:

```go
func (c *csvIterator) NextRow() (row []string, end bool, err error) {
	row, e := c.reader.Read()
	if e != nil {
		if errors.Is(e, io.EOF) {
			return nil, true, nil
		}
		return nil, false, err   // <-- returns the named return `err`, which is never assigned (always nil)
	}
	return row, false, nil
}
```

The actual read error is captured in the local variable `e`. The named
return `err` is never assigned anywhere in the function, so it is always
`nil`. On the non-EOF error path the function therefore returns
`(nil, false, nil)` instead of surfacing `e`.

### Why it matters

The caller `parseByRowIterator` (`parse_iter.go`) relies on this error to
abort parsing:

```go
row, end, err := iter.NextRow()
if err != nil {
    return nil, err
}
if end {
    break
}
```

Because `err` is `nil`, a malformed CSV row (e.g. a quoting error or a
`ErrFieldCount` mismatch surfaced by `encoding/csv`) is not reported.
The loop treats the failed read as an empty row, drops it, and continues
— so CSV parsing silently loses data instead of failing loudly. EOF is
handled separately and correctly (`return nil, true, nil`); only the real
error path is broken.

### Fix

Return the actual error `e` on the non-EOF path:

```go
		return nil, false, e
```

One-line, focused change. The EOF and success paths are unchanged.

### Verification

Verified by reading; not executed (no Go toolchain available in this
environment). The change is a direct language-semantics fix: the local
`e` holds the real error from `csv.Reader.Read()`, while the named return
`err` is provably nil at that point.