### PR TITLE
dao: fix InitTx returning nil error on Begin failure

### DIFF
--- a/backend/domain/knowledge/internal/dal/dao/knowledge.go
+++ b/backend/domain/knowledge/internal/dal/dao/knowledge.go
@@ -85,7 +85,7 @@ func (dao *KnowledgeDAO) FilterEnableKnowledge(ctx context.Context, knowledgeIDs
 func (dao *KnowledgeDAO) InitTx() (tx *gorm.DB, err error) {
 	tx = dao.DB.Begin()
 	if tx.Error != nil {
-		return nil, err
+		return nil, tx.Error
 	}
 	return
 }


### PR DESCRIPTION
## Bug

In `InitTx()`, when `dao.DB.Begin()` fails (rare, e.g. connection error), the function returns `(nil, nil)` instead of `(nil, tx.Error)` because it returns the named return `err` which is uninitialized (always nil).

## Root cause

```go
func (dao *KnowledgeDAO) InitTx() (tx *gorm.DB, err error) {
    tx = dao.DB.Begin()
    if tx.Error != nil {
        return nil, err   // err is nil here (named return, never assigned)
    }
    return
}
```

The named return `err` is never assigned a value in this function. When `tx.Error` is non-nil, line 88 returns `(nil, nil)` — the caller receives a nil error, proceeds to use the nil `tx`, and panics with a nil pointer dereference.

## Fix

Return `tx.Error` instead of `err` on the error path:

```go
        return nil, tx.Error
```

This is a pure Go language semantics bug — the named-error pattern works when `err` is assigned upstream, but it is not in this function. Exact same class as the CSV/user.go nil-error bugs fixed previously.

## Verification

Verified by reading the source; no Go toolchain available on this machine. The bug is provable by static analysis: `err` is a named return of type `error`, default-initialized to `nil`, and never assigned in the function body.

## File changed

`backend/domain/knowledge/internal/dal/dao/knowledge.go` line 88