### PR TITLE
fix(vikingdb): correct inverted branch polarity in genFilter partition filter

### DIFF
--- a/backend/infra/document/searchstore/impl/vikingdb/vikingdb_searchstore.go
+++ b/backend/infra/document/searchstore/impl/vikingdb/vikingdb_searchstore.go
@@ -320,7 +320,7 @@ func (v *vkSearchStore) genFilter(ctx context.Context, co *retriever.Options, ro
 
 		op := map[string]any{"op": "must", "field": key, "conds": conds}
 
-		if filter != nil {
+		if filter == nil {
 			filter = op
 		} else {
 			filter = map[string]any{


### PR DESCRIPTION
## Problem

In `backend/infra/document/searchstore/impl/vikingdb/vikingdb_searchstore.go`, the `genFilter` function combines a DSL scope filter with the partition filter. The branch polarity is inverted:

```go
op := map[string]any{"op": "must", "field": key, "conds": conds}

if filter != nil {
    filter = op                       // overwrites & DROPS the DSL scope filter
} else {
    filter = map[string]any{
        "op":    "and",
        "conds": []map[string]any{op, filter},  // filter is nil here -> nil embedded in conds
    }
}
```

Consequences:

- When a DSL scope filter **exists** (`filter != nil`), `filter = op` silently discards it, keeping only the partition filter. Retrieval then ignores the caller's scope constraints, returning documents that should have been filtered out.
- When there is **no** DSL filter (`filter == nil`), the `else` branch builds `{"op":"and","conds":[op, filter]}` where `filter` is `nil`, embedding a nil map into the conds slice.

## Fix

Swap the condition so the branch bodies match their intent. The bodies are already correct for the swapped condition, so this is a minimal one-character change:

```go
if filter == nil {
    filter = op                       // no DSL filter -> just the partition op
} else {
    filter = map[string]any{          // DSL filter present -> AND the two together
        "op":    "and",
        "conds": []map[string]any{op, filter},
    }
}
```

Now:
- No DSL filter -> `filter = op` (partition-only), no nil embedded.
- DSL filter present -> `{op:and, conds:[op, filter]}`, preserving both constraints.

## Verification

Verified by reading the source; not executed (no Go toolchain available in this environment). The change is a +1/-1 diff limited to the single inverted condition; the unrelated correct usage of `if filter != nil` at the call site (SetFilter) is untouched.
