### PR TITLE
fix(config): read ALLOW_REGISTRATION_EMAIL for registration whitelist

### DIFF
--- a/backend/bizpkg/config/base/base.go
+++ b/backend/bizpkg/config/base/base.go
@@ -76,7 +76,7 @@ func getBasicConfigurationFromOldConfig() *config.BasicConfiguration {
 	return &config.BasicConfiguration{
 		AdminEmails:             "",
 		DisableUserRegistration: disableUserRegistration,
-		AllowRegistrationEmail:  os.Getenv(consts.DisableUserRegistration),
+		AllowRegistrationEmail:  os.Getenv(consts.AllowRegistrationEmail),
 		PluginConfiguration: &config.PluginConfiguration{
 			CozeSaasPluginEnabled: envkey.GetBoolD("COZE_SAAS_PLUGIN_ENABLED", false),
 			CozeAPIToken:          envkey.GetString("COZE_SAAS_API_KEY"),


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.

fix(config): 修复注册白名单读取错误环境变量

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:
`getBasicConfigurationFromOldConfig()` populates `AllowRegistrationEmail` from `os.Getenv(consts.DisableUserRegistration)`, so when `DISABLE_USER_REGISTRATION=true` the whitelist becomes `["true"]` and every registration is rejected, even for emails listed in `ALLOW_REGISTRATION_EMAIL`. This restores the intended behavior from PR #208 by reading `consts.AllowRegistrationEmail`.

zh(optional): 修复 `DISABLE_USER_REGISTRATION=true` 时注册白名单 `ALLOW_REGISTRATION_EMAIL` 完全失效的问题——基础配置迁移函数读错了环境变量,导致白名单恒为 `["true"]`,所有注册请求都被拒绝。

#### (Optional) Which issue(s) this PR fixes:

Fixes #2731
