### PR TITLE
fix(docker): force LF for shell scripts and fail ES init loudly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,7 @@ yarn.lock merge=binary
 # For more information, see this issue: https://github.com/microsoft/rushstack/issues/1088
 #
 *.json linguist-language=JSON-with-Comments
+
+# Force LF for shell scripts so Windows checkouts still run in Linux containers
+*.sh text eol=lf
+*.bash text eol=lf

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -187,9 +187,12 @@ services:
 
           # Run ES initialization script
           echo 'Running Elasticsearch initialization...'
-          sed 's/\r$$//' /setup_es.sh > /setup_es_fixed.sh
+          tr -d '\r' < /setup_es.sh > /setup_es_fixed.sh
           chmod +x /setup_es_fixed.sh
-          /setup_es_fixed.sh --index-dir /es_index_schema
+          if ! /setup_es_fixed.sh --index-dir /es_index_schema; then
+            echo 'Elasticsearch initialization FAILED' >&2
+            exit 1
+          fi
           # Create marker file indicating initialization completion
           touch /tmp/es_init_complete
           echo 'Elasticsearch initialization completed successfully!'


### PR DESCRIPTION
## Summary
- Add `*.sh` / `*.bash` `eol=lf` to `.gitattributes` so Windows checkouts keep LF for container scripts (fixes CRLF-related ES init failures).
- Harden `docker-compose` ES init: strip CR with `tr` and `exit 1` if `setup_es` fails (instead of printing success after a broken script).

Fixes #2725

## Testing plan
- [ ] On Windows, clone fresh and confirm `docker/volumes/elasticsearch/setup_es.sh` is LF.
- [ ] `docker compose up -d` creates ES indexes without `cannot execute: required file not found`.
- [ ] Intentionally break setup script and confirm compose no longer reports false success.