### PR TITLE
fix(fetch-stream): batch onMessage per animation frame to fix streaming INP (#2449)

### DIFF
--- a/frontend/packages/arch/fetch-stream/src/fetch-stream.ts
+++ b/frontend/packages/arch/fetch-stream/src/fetch-stream.ts
@@ -224,9 +224,41 @@ export async function fetchStream<Message = ParseEvent, DataClump = unknown>(
         },
       });
 
+      // Batch onMessage dispatch across animation frames so a burst of streamed
+      // chunks doesn't monopolize the main thread (fixes INP jank during
+      // streaming, see #2449). Order is preserved; messages already queued are
+      // flushed when the stream closes so none are dropped.
+      const flushScheduler = (() => {
+        const g = globalThis as unknown as {
+          requestAnimationFrame?: (cb: (t: number) => void) => number;
+          queueMicrotask?: (cb: () => void) => void;
+        };
+        if (typeof g.requestAnimationFrame === 'function') {
+          return (cb: () => void) => void g.requestAnimationFrame!(() => cb());
+        }
+        if (typeof g.queueMicrotask === 'function') {
+          return (cb: () => void) => g.queueMicrotask!(cb);
+        }
+        return (cb: () => void) => void setTimeout(cb, 0);
+      })();
+
+      let pendingMessages: Array<{ message: Message; dataClump: DataClump }> = [];
+      let frameScheduled = false;
+      const flushPending = () => {
+        frameScheduled = false;
+        if (!pendingMessages.length) {
+          return;
+        }
+        const batch = pendingMessages;
+        pendingMessages = [];
+        for (const p of batch) {
+          onMessage?.(p);
+        }
+      };
+
       const streamWriter = new WritableStream<Message>({
-        async write(chunk, controller) {
-          // Write messages asynchronously to avoid false panic pipeline flow in callbacks
+        async write(chunk, _controller) {
+          // Yield a microtask to avoid false panic pipeline flow in callbacks.
           await Promise.resolve();
           const param = { message: chunk, dataClump };
           const validateResult = validateMessage?.(param);
@@ -238,7 +270,21 @@ export async function fetchStream<Message = ParseEvent, DataClump = unknown>(
             throw validateResult.error;
           }
 
-          onMessage?.(param);
+          // Defer onMessage to the next frame so a burst of chunks doesn't run
+          // heavy per-message work back-to-back on the main thread.
+          pendingMessages.push(param);
+          if (!frameScheduled) {
+            frameScheduled = true;
+            flushScheduler(flushPending);
+          }
+        },
+        close() {
+          // Deliver any remaining messages before the stream closes.
+          flushPending();
+        },
+        abort() {
+          // Best-effort: still deliver queued messages on abort/cancel.
+          flushPending();
         },
       });
 


### PR DESCRIPTION
## Summary
The WritableStream writer in fetch-stream.ts called onMessage synchronously for every parsed chunk. During a burst of streamed chunks this ran heavy per-message work back-to-back on the main thread, spiking INP and freezing input responsiveness (see #2449).

## Changes
- Queue incoming messages and flush them once per animation frame (requestAnimationFrame) so the browser can paint between frames.
- Message order is preserved.
- Any queued messages are flushed on stream close/abort so none are dropped.
- Non-DOM environments (Node / jsdom / worker) fall back to queueMicrotask / setTimeout.
- validateMessage still runs synchronously in write(), so the existing error-interrupt path is unchanged.

## Risk / testing
- This only changes *when* onMessage runs (deferred to a frame), not *what* it receives.
- Single-message streaming is unaffected in behavior (just delivered on the next frame).
- CI type-check / lint should pass; runtime INP improvement is best verified in a browser streaming scenario.

Signed-off-by: PiedPiper911 <PiedPiper911@users.noreply.github.com>