### PR TITLE
docs: replace project name placeholders in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We use [git-flow](https://nvie.com/posts/a-successful-git-branching-model/) as o
 
 ## Bugs
 ### 1. How to Find Known Issues
-We are using [Github Issues](https://github.com/coze-dev/{project_name}/issues) for our public bugs. We keep a close eye on this and try to make it clear when we have an internal fix in progress. Before filing a new task, try to make sure your problem doesn’t already exist.
+We are using [Github Issues](https://github.com/coze-dev/coze-studio/issues) for our public bugs. We keep a close eye on this and try to make it clear when we have an internal fix in progress. Before filing a new task, try to make sure your problem doesn’t already exist.
 
 ### 2. Reporting New Issues
 Providing a reduced test code is a recommended way for reporting issues. Then can place in:
@@ -23,9 +23,9 @@ Please do not report the safe disclosure of bugs to public issues. Contact us by
 
 ## Submit a Pull Request
 Before you submit your Pull Request (PR) consider the following guidelines:
-1. Search [GitHub](https://github.com/coze-dev/{project_name}/pulls) for an open or closed PR that relates to your submission. You don't want to duplicate existing efforts.
+1. Search [GitHub](https://github.com/coze-dev/coze-studio/pulls) for an open or closed PR that relates to your submission. You don't want to duplicate existing efforts.
 2. Be sure that an issue describes the problem you're fixing, or documents the design for the feature you'd like to add. Discussing the design upfront helps to ensure that we're ready to accept your work.
-3. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the coze-dev {project_name} repo.
+3. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the coze-dev/coze-studio repo.
 4. In your forked repository, make your changes in a new git branch:
     ```
     git checkout -b my-fix-branch main
@@ -38,7 +38,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     ```
     git push origin my-fix-branch
     ```
-9. In GitHub, send a pull request to `{project_name}:main`
+9. In GitHub, send a pull request to `coze-studio:main`
 
 ## Contribution Prerequisites
 - Our development environment keeps up with [Go Official](https://golang.org/project/).


### PR DESCRIPTION
#### What type of PR is this?

docs: Documentation only changes

#### Check the PR title.

- [x] This PR title match the format: `<type>(optional scope): <description>`
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Add documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.

docs: 替换贡献指南中的项目名占位符

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

Replace all four remaining `{project_name}` placeholders in `CONTRIBUTING.md` with the actual repository name. This also changes the Issues and Pull Requests links from HTTP 404 targets to the live `coze-dev/coze-studio` pages.

Validation:

- Confirmed no `{project_name}` placeholders remain in `CONTRIBUTING.md`.
- Confirmed both updated GitHub links return HTTP 200.
- `git diff --check` passes.

zh(optional):

将 `CONTRIBUTING.md` 中剩余的 4 个 `{project_name}` 占位符替换为实际仓库名，并修复 Issues 与 Pull Requests 两条 404 链接。

#### (Optional) Which issue(s) this PR fixes:

Fixes #2737