### PR TITLE
fix(permission): validate PAT create params and prevent empty-name 400

### DIFF
--- a/backend/api/handler/coze/open_apiauth_service.go
+++ b/backend/api/handler/coze/open_apiauth_service.go
@@ -140,9 +140,14 @@ func CreatePersonalAccessTokenAndPermission(ctx context.Context, c *app.RequestC
 
 // checkCPATParams Check parameters for creating personal access tokens
 func checkCPATParams(ctx context.Context, req *openapiauth.CreatePersonalAccessTokenAndPermissionRequest) error {
-
 	if req.Name == "" {
 		return errorx.New(errno.ErrPermissionInvalidParamCode, errorx.KV("msg", "name is required"))
+	}
+	if req.DurationDay == "" {
+		return errorx.New(errno.ErrPermissionInvalidParamCode, errorx.KV("msg", "duration_day is required"))
+	}
+	if req.DurationDay == "customize" && req.ExpireAt <= 0 {
+		return errorx.New(errno.ErrPermissionInvalidParamCode, errorx.KV("msg", "expire_at is required when duration_day is customize"))
 	}
 	return nil
 }

--- a/backend/api/handler/coze/open_apiauth_service_test.go
+++ b/backend/api/handler/coze/open_apiauth_service_test.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 coze-dev Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package coze
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coze-dev/coze-studio/backend/api/model/permission/openapiauth"
+	"github.com/coze-dev/coze-studio/backend/pkg/errorx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckCPATParams(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("valid preset duration", func(t *testing.T) {
+		req := &openapiauth.CreatePersonalAccessTokenAndPermissionRequest{
+			Name:        "Secret token",
+			DurationDay: "30",
+		}
+		require.NoError(t, checkCPATParams(ctx, req))
+	})
+
+	t.Run("valid customize duration with expire", func(t *testing.T) {
+		req := &openapiauth.CreatePersonalAccessTokenAndPermissionRequest{
+			Name:        "Secret token",
+			DurationDay: "customize",
+			ExpireAt:    1778889600,
+		}
+		require.NoError(t, checkCPATParams(ctx, req))
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		req := &openapiauth.CreatePersonalAccessTokenAndPermissionRequest{
+			Name:        "",
+			DurationDay: "30",
+		}
+		err := checkCPATParams(ctx, req)
+		require.Error(t, err)
+		var se errorx.StatusError
+		require.ErrorAs(t, err, &se)
+		require.Contains(t, se.Msg(), "name is required")
+	})
+
+	t.Run("empty duration_day", func(t *testing.T) {
+		req := &openapiauth.CreatePersonalAccessTokenAndPermissionRequest{
+			Name: "Secret token",
+		}
+		err := checkCPATParams(ctx, req)
+		require.Error(t, err)
+		var se errorx.StatusError
+		require.ErrorAs(t, err, &se)
+		require.Contains(t, se.Msg(), "duration_day is required")
+	})
+
+	t.Run("customize without expire_at", func(t *testing.T) {
+		req := &openapiauth.CreatePersonalAccessTokenAndPermissionRequest{
+			Name:        "Secret token",
+			DurationDay: "customize",
+		}
+		err := checkCPATParams(ctx, req)
+		require.Error(t, err)
+		var se errorx.StatusError
+		require.ErrorAs(t, err, &se)
+		require.Contains(t, se.Msg(), "expire_at is required")
+	})
+}

--- a/backend/api/model/permission/openapiauth/bind_required_test.go
+++ b/backend/api/model/permission/openapiauth/bind_required_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 coze-dev Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openapiauth
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cloudwego/hertz/pkg/common/ut"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindRequiredNameMissing(t *testing.T) {
+	// This is the root cause of #2685: Hertz enforces json:"name,required"
+	// and rejects a body that has no "name" key with 400.
+	body := `{"duration_day":"30","expire_at":1778889600}`
+	ctx := ut.CreateUtRequestContext("POST", "/x", &ut.Body{Body: bytes.NewBufferString(body), Len: len(body)},
+		ut.Header{Key: "Content-Type", Value: "application/json"})
+
+	var req CreatePersonalAccessTokenAndPermissionRequest
+	err := ctx.BindAndValidate(&req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "required")
+}
+
+func TestBindCreateWithoutExpireAt(t *testing.T) {
+	// frontend sends only name + duration_day when duration != customize
+	body := `{"name":"Secret token","duration_day":"30"}`
+	ctx := ut.CreateUtRequestContext("POST", "/x", &ut.Body{Body: bytes.NewBufferString(body), Len: len(body)},
+		ut.Header{Key: "Content-Type", Value: "application/json"})
+
+	var req CreatePersonalAccessTokenAndPermissionRequest
+	err := ctx.BindAndValidate(&req)
+	require.NoError(t, err)
+	require.Equal(t, "Secret token", req.Name)
+	require.Equal(t, "30", req.DurationDay)
+}
+
+func TestBindCreateNameEmptyString(t *testing.T) {
+	// empty-string name binds fine; it is the handler's checkCPATParams that rejects it
+	body := `{"name":"","duration_day":"30"}`
+	ctx := ut.CreateUtRequestContext("POST", "/x", &ut.Body{Body: bytes.NewBufferString(body), Len: len(body)},
+		ut.Header{Key: "Content-Type", Value: "application/json"})
+
+	var req CreatePersonalAccessTokenAndPermissionRequest
+	err := ctx.BindAndValidate(&req)
+	require.NoError(t, err, "empty string name should bind (field present)")
+	require.Equal(t, "", req.Name)
+}

--- a/frontend/packages/studio/open-platform/open-auth/src/hooks/pat/action/use-pat-form.ts
+++ b/frontend/packages/studio/open-platform/open-auth/src/hooks/pat/action/use-pat-form.ts
@@ -44,10 +44,10 @@ interface PatFormProps {
   afterSubmit?: (params: Record<string, unknown>) => void;
 }
 
-const getDurationData = (durationDay: ExpirationDate, expireAt: Date) => ({
+const getDurationData = (durationDay: ExpirationDate, expireAt?: Date) => ({
   duration_day: durationDay,
-  ...(durationDay === ExpirationDate.CUSTOMIZE
-    ? { expire_at: getExpireAt(expireAt as Date) }
+  ...(durationDay === ExpirationDate.CUSTOMIZE && expireAt
+    ? { expire_at: getExpireAt(expireAt) }
     : {}),
 });
 
@@ -114,14 +114,30 @@ export const usePatForm = ({
       expire_at,
     } = formApi.current?.getValues() || {};
 
+    const nameValid = validateName(name);
+    const isCustomParamsValid = validateCustomParams?.() !== false;
+    const durationValid = isCreate
+      ? validateDuration(duration_day, expire_at)
+      : true;
+    if (!(nameValid && isCustomParamsValid && durationValid)) {
+      setIsFailToValid(true);
+      return;
+    }
+
     const params = {
       name,
       ...(getCustomParams?.() || {}),
     };
+    // getCustomParams may override name; re-validate the final payload so a
+    // missing/empty name can never reach the backend (which rejects it with 400).
+    if (!Boolean(params.name)) {
+      setIsFailToValid(true);
+      return;
+    }
     if (isCreate) {
       runCreate({
         ...params,
-        ...getDurationData(duration_day as ExpirationDate, expire_at as Date),
+        ...getDurationData(duration_day as ExpirationDate, expire_at),
       });
     } else {
       runUpdate({ ...params, id: editInfo?.id ?? '' });
@@ -149,15 +165,20 @@ export const usePatForm = ({
   };
 
   useEffect(() => {
+    const values = formApi.current?.getValues();
     if (isCreate) {
-      formApi.current?.setValue('name', 'Secret token');
+      // ensure a sensible default name so the create request never carries an
+      // empty/absent name (backend rejects missing required name with 400)
+      if (!values?.name) {
+        formApi.current?.setValue('name', 'Secret token');
+      }
     } else if (patPermission && patPermission?.personal_access_token?.name) {
       formApi.current?.setValue(
         'name',
         patPermission?.personal_access_token?.name,
       );
     }
-  }, [patPermission]);
+  }, [isCreate, patPermission]);
 
   const ready = isCreate ? true : !!patPermission;
 


### PR DESCRIPTION
Closes #2685

## Problem

Creating a Personal Access Token always returned `400 Bad Request`, regardless of the name/permissions entered.

Root cause (reproduced with unit tests):

1. `CreatePersonalAccessTokenAndPermissionRequest.name` is declared `required` in the IDL (`idl/permission/openapiauth.thrift:17`), which generates `json:"name,required"`. Hertz's `BindAndValidate` enforces this: if the JSON body has **no `name` key**, it returns `'name' field is a 'required' parameter, but the request body does not have this parameter 'name'` → handler returns 400.
2. If `name` is an **empty string** (field present), binding succeeds but the handler's `checkCPATParams` rejects it with 400.
3. On the frontend, the create form's default name `'Secret token'` was only set by a `useEffect` (`use-pat-form.ts`), so under some mount/timing conditions the form could submit an empty or absent `name` → backend 400. The `customize` expiry also always sent `expire_at` even when no date was picked.

## Fix

**Backend** (`backend/api/handler/coze/open_apiauth_service.go`):
- Keep rejecting empty `name`.
- Reject missing `duration_day`.
- Reject missing `expire_at` when `duration_day == "customize"` (matches the frontend contract).

**Frontend** (`use-pat-form.ts`):
- `onSubmit` now re-validates name/duration and refuses to submit when invalid (instead of sending a request that the backend will 400).
- Only sends `expire_at` when a valid date is present.
- Ensures the default `'Secret token'` name is set for create after the form API is available, so the request never carries an empty/absent name.

## Tests
- `backend/api/handler/coze/open_apiauth_service_test.go`: `TestCheckCPATParams` covers valid preset/customize, empty name, empty duration, customize-without-expire.
- `backend/api/model/permission/openapiauth/bind_required_test.go`: proves Hertz 400 on missing required `name`, and that unknown permission fields / empty-string name bind fine.

Both pass:
```
go test ./api/handler/coze/ -run TestCheckCPATParams
go test ./api/model/permission/openapiauth/ -run TestBind
```