### PR TITLE
fix(workflow): count input tokens in chatflow done usage

### DIFF
--- a/backend/application/workflow/chatflow.go
+++ b/backend/application/workflow/chatflow.go
@@ -879,7 +879,7 @@ func (w *ApplicationService) convertToChatFlowRunResponseList(ctx context.Contex
 					chatDoneEvent.Usage = &vo.Usage{
 						InputTokens:  &msg.StateMessage.Usage.InputTokens,
 						OutputTokens: &msg.StateMessage.Usage.OutputTokens,
-						TokenCount:   ptr.Of(msg.StateMessage.Usage.OutputTokens + msg.StateMessage.Usage.OutputTokens),
+						TokenCount:   ptr.Of(msg.StateMessage.Usage.InputTokens + msg.StateMessage.Usage.OutputTokens),
 					}
 				}
 


### PR DESCRIPTION
Fixes a copy-paste bug in the chatflow done event usage aggregation.

```go
// before
TokenCount: ptr.Of(msg.StateMessage.Usage.OutputTokens + msg.StateMessage.Usage.OutputTokens)
// after
TokenCount: ptr.Of(msg.StateMessage.Usage.InputTokens + msg.StateMessage.Usage.OutputTokens)
```

`TokenCount` was computed as `OutputTokens + OutputTokens`, double-counting output tokens and dropping input tokens entirely. Every other usage aggregation in the codebase sums input + output:
- `application/workflow/workflow.go:1503` (`InputTokens + OutputTokens`)
- `application/workflow/workflow.go:1846` and `:1909`
- `domain/conversation/agentrun/internal/chatflow_run.go:171`

This aligns `chatflow.go` with the same convention. No behavior other than the reported metric changes.