### PR TITLE
fix(workflow): stop mutating shared http.DefaultClient in http requester

### DIFF
--- a/backend/domain/workflow/internal/nodes/httprequester/http_requester.go
+++ b/backend/domain/workflow/internal/nodes/httprequester/http_requester.go
@@ -340,12 +340,15 @@ func (c *Config) Build(_ context.Context, _ *schema.NodeSchema, _ ...schema.Buil
 		bodyConfig:      c.BodyConfig,
 		md5FieldMapping: c.MD5FieldMapping,
 	}
-	client := http.DefaultClient
+	// Copy the shared http.DefaultClient instead of mutating it. http.DefaultClient
+	// is a process-wide singleton; writing its Timeout here would race with and
+	// clobber other concurrent workflows (and httpGet below) that rely on it.
+	client := *http.DefaultClient
 	if c.Timeout > 0 {
 		client.Timeout = c.Timeout
 	}
 
-	hg.client = client
+	hg.client = &client
 
 	return hg, nil
 }
@@ -623,8 +626,11 @@ func httpGet(ctx context.Context, url string) (*http.Response, error) {
 		return nil, err
 	}
 
-	http.DefaultClient.Timeout = time.Second * defaultGetFileTimeout
-	return http.DefaultClient.Do(request)
+	// Copy the shared http.DefaultClient so the file-download timeout does not
+	// mutate the process-wide client used by concurrent requests.
+	client := *http.DefaultClient
+	client.Timeout = time.Second * defaultGetFileTimeout
+	return client.Do(request)
 }
 
 func (hg *HTTPRequester) ToCallbackInput(_ context.Context, input map[string]any) (

--- a/backend/domain/workflow/internal/nodes/httprequester/http_requester_test.go
+++ b/backend/domain/workflow/internal/nodes/httprequester/http_requester_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -394,4 +395,32 @@ func TestInvoke(t *testing.T) {
 		assert.Equal(t, `{"message":"success"}`, result["body"])
 		assert.Equal(t, int64(200), result["statusCode"])
 	})
+}
+
+func TestBuildDoesNotMutateDefaultClient(t *testing.T) {
+	originalTimeout := http.DefaultClient.Timeout
+	defer func() { http.DefaultClient.Timeout = originalTimeout }()
+
+	cfg := &Config{
+		Method:     "GET",
+		Timeout:    time.Second * 7,
+		RetryTimes: 0,
+	}
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := cfg.Build(context.Background(), &schema.NodeSchema{})
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	// Building HTTPRequester nodes must never change the process-wide default
+	// client; otherwise concurrent workflows race on http.DefaultClient.Timeout.
+	assert.Equal(t, originalTimeout, http.DefaultClient.Timeout,
+		"http.DefaultClient.Timeout was mutated by Config.Build")
 }


### PR DESCRIPTION
Fixes a data race / timeout-pollution bug in the HTTP requester workflow node.

**Problem**

`Config.Build` and `httpGet` wrote `Timeout` directly onto the process-wide `http.DefaultClient` singleton:

```go
client := http.DefaultClient
if c.Timeout > 0 {
    client.Timeout = c.Timeout // mutates the global singleton
}
...
http.DefaultClient.Timeout = time.Second * defaultGetFileTimeout
return http.DefaultClient.Do(request)
```

Because `http.DefaultClient` is shared by every request in the process, concurrent workflows (and the file-download helper) race on `Timeout` and clobber each other's request timeouts — an `http.Client` must not have its exported fields mutated after use (concurrent reads/writes are a data race).

**Fix**

Copy the default client (sharing its `Transport`/policy fields) before setting `Timeout`:

```go
client := *http.DefaultClient
if c.Timeout > 0 {
    client.Timeout = c.Timeout
}
hg.client = &client
```

```go
client := *http.DefaultClient
client.Timeout = time.Second * defaultGetFileTimeout
return client.Do(request)
```

**Test**

`TestBuildDoesNotMutateDefaultClient` runs `Config.Build` concurrently and asserts `http.DefaultClient.Timeout` is unchanged. It fails on the old code (`http.DefaultClient.Timeout was mutated by Config.Build`) and passes with the fix.

```
go test ./domain/workflow/internal/nodes/httprequester/
```