### PR TITLE
fix(workflow): guard nil intermediateMessage in chatflow suggest

### DIFF
--- a/backend/application/workflow/chatflow.go
+++ b/backend/application/workflow/chatflow.go
@@ -832,7 +832,7 @@ func (w *ApplicationService) convertToChatFlowRunResponseList(ctx context.Contex
 			switch msg.StateMessage.Status {
 			case entity.WorkflowSuccess:
 				suggestWorkflowResponse := make([]*workflow.ChatFlowRunResponse, 0, 3)
-				if info.suggestReplyInfo != nil && info.suggestReplyInfo.IsSetSuggestReplyMode() && info.suggestReplyInfo.GetSuggestReplyMode() != workflow.SuggestReplyInfoMode_Disable {
+				if info.suggestReplyInfo != nil && info.suggestReplyInfo.IsSetSuggestReplyMode() && info.suggestReplyInfo.GetSuggestReplyMode() != workflow.SuggestReplyInfoMode_Disable && intermediateMessage != nil {
 					sInfo := &vo.SuggestInfo{
 						UserInput:    userMessage,
 						AnswerInput:  schema.AssistantMessage(intermediateMessage.Content, nil),


### PR DESCRIPTION
Fixes a nil pointer dereference in the chatflow success path.

**Problem**

In `application/workflow/chatflow.go`, the `WorkflowSuccess` branch dereferences `intermediateMessage.Content` when suggest mode is enabled:

```go
if info.suggestReplyInfo != nil && ... && info.suggestReplyInfo.GetSuggestReplyMode() != ...Disable {
    sInfo := &vo.SuggestInfo{
        AnswerInput: schema.AssistantMessage(intermediateMessage.Content, nil),
        ...
```

But `intermediateMessage` starts as `nil` and is only assigned when a `DataMessage` is received (the `needRegeneratedMessage` path, around line 1106). A workflow that completes without emitting any `DataMessage` (e.g. an end-only workflow, or one whose outputs are all `StateMessage`s) reaches this line with `intermediateMessage == nil` → nil pointer dereference panic.

Every other access site in the same function (`:818`, `:931`, `:953`) already guards with `intermediateMessage != nil`; this one was missed.

**Fix**

Add `&& intermediateMessage != nil` to the suggest-mode condition. When there is no intermediate message there is nothing to base suggestions on, so suggest generation is skipped (safe degradation) instead of panicking.

```
go build ./application/workflow/
go test ./application/workflow/
```
