### PR TITLE
fix(database): use real LIKE wildcards instead of literal %s

### DIFF
--- a/backend/crossdomain/database/impl/database.go
+++ b/backend/crossdomain/database/impl/database.go
@@ -409,7 +409,7 @@ func resolveRightValue(operator model.Operation, right any) (string, []*model.SQ
 	if isLikeOrNotLike(operator) {
 		var (
 			value = "?"
-			v     = "%s" + rightValue + "%s"
+			v     = "%" + rightValue + "%"
 		)
 		return value, []*model.SQLParamVal{{ValueType: table.FieldItemType_Text, Value: &v}}, nil
 	}

--- a/backend/crossdomain/database/impl/database_test.go
+++ b/backend/crossdomain/database/impl/database_test.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 coze-dev Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package impl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coze-dev/coze-studio/backend/crossdomain/database/model"
+)
+
+func TestResolveRightValueLikeWildcard(t *testing.T) {
+	value, vals, err := resolveRightValue(model.Operation_LIKE, "alice")
+	require.NoError(t, err)
+	require.Equal(t, "?", value)
+	require.Len(t, vals, 1)
+	require.Equal(t, "%alice%", *vals[0].Value, "LIKE parameter must be %value% so the wildcard matches")
+}
+
+func TestResolveRightValueNotLikeWildcard(t *testing.T) {
+	value, vals, err := resolveRightValue(model.Operation_NOT_LIKE, "tmp")
+	require.NoError(t, err)
+	require.Equal(t, "?", value)
+	require.Len(t, vals, 1)
+	require.Equal(t, "%tmp%", *vals[0].Value)
+}
+
+func TestResolveRightValueEquality(t *testing.T) {
+	value, vals, err := resolveRightValue(model.Operation_EQUAL, "alice")
+	require.NoError(t, err)
+	require.Equal(t, "?", value)
+	require.Len(t, vals, 1)
+	require.Equal(t, "alice", *vals[0].Value, "non-LIKE operators must keep the raw value")
+}


### PR DESCRIPTION
Fixes a broken LIKE/NOT LIKE filter in the memory-database SQL builder.

**Problem**

`resolveRightValue` built the LIKE parameter as `"%s" + rightValue + "%s"`:

```go
v = %s + rightValue + %s
```

This produces the literal text `%s<value>%s`, so a `LIKE` condition matches nothing and `NOT LIKE` matches everything. The intended SQL wildcards are `%`:

```go
v = % + rightValue + %
```

This matches the existing usage in `domain/memory/database/internal/dal/online_database_info.go:256` (`"%" + *filter.TableName + "%"`).

**Tests**

`database_test.go` adds:
- `TestResolveRightValueLikeWildcard` / `TestResolveRightValueNotLikeWildcard`: parameter is `%value%`.
- `TestResolveRightValueEquality`: non-LIKE operators keep the raw value.

The LIKE test fails on the old code.

```
go test ./crossdomain/database/impl/ -run TestResolveRightValue
```