### PR TITLE
fix(parser): honor ParsingStrategy.RowsCount in parseByRowIterator

### DIFF
--- a/backend/infra/document/parser/impl/builtin/parse_iter.go
+++ b/backend/infra/document/parser/impl/builtin/parse_iter.go
@@ -111,7 +111,7 @@ func parseByRowIterator(iter rowIterator, config *contract.Config, opts ...parse
 		}
 
 		i++
-		if ps.RowsCount != 0 && len(docs) == ps.RowsCount {
+		if ps.RowsCount != 0 && len(expData) >= ps.RowsCount {
 			break
 		}
 	}

--- a/backend/infra/document/parser/impl/builtin/parse_iter_test.go
+++ b/backend/infra/document/parser/impl/builtin/parse_iter_test.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 coze-dev Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package builtin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coze-dev/coze-studio/backend/infra/document"
+	contract "github.com/coze-dev/coze-studio/backend/infra/document/parser"
+)
+
+type sliceRowIterator struct {
+	rows [][]string
+	idx  int
+}
+
+func (s *sliceRowIterator) NextRow() (row []string, end bool, err error) {
+	if s.idx >= len(s.rows) {
+		return nil, true, nil
+	}
+	r := s.rows[s.idx]
+	s.idx++
+	return r, false, nil
+}
+
+// TestParseByRowIteratorRowsCount verifies that ParsingStrategy.RowsCount
+// limits how many data rows are actually parsed.
+func TestParseByRowIteratorRowsCount(t *testing.T) {
+	iter := &sliceRowIterator{
+		rows: [][]string{
+			{"name", "age"},
+			{"a", "1"},
+			{"b", "2"},
+			{"c", "3"},
+			{"d", "4"},
+			{"e", "5"},
+			{"f", "6"},
+			{"g", "7"},
+		},
+	}
+	cfg := &contract.Config{
+		ParsingStrategy: &contract.ParsingStrategy{
+			HeaderLine:    0,
+			DataStartLine: 1,
+			RowsCount:     3,
+			Columns: []*document.Column{
+				{Name: "name", Type: document.TableColumnTypeString, Sequence: 0},
+				{Name: "age", Type: document.TableColumnTypeString, Sequence: 1},
+			},
+		},
+	}
+
+	docs, err := parseByRowIterator(iter, cfg)
+	require.NoError(t, err)
+	require.Len(t, docs, 3, "RowsCount=3 must cap the number of parsed rows")
+}
+
+// TestParseByRowIteratorAllRows verifies RowsCount=0 means no limit.
+func TestParseByRowIteratorAllRows(t *testing.T) {
+	iter := &sliceRowIterator{
+		rows: [][]string{
+			{"name", "age"},
+			{"a", "1"},
+			{"b", "2"},
+			{"c", "3"},
+		},
+	}
+	cfg := &contract.Config{
+		ParsingStrategy: &contract.ParsingStrategy{
+			HeaderLine:    0,
+			DataStartLine: 1,
+			RowsCount:     0,
+			Columns: []*document.Column{
+				{Name: "name", Type: document.TableColumnTypeString, Sequence: 0},
+				{Name: "age", Type: document.TableColumnTypeString, Sequence: 1},
+			},
+		},
+	}
+
+	docs, err := parseByRowIterator(iter, cfg)
+	require.NoError(t, err)
+	require.Len(t, docs, 3, "RowsCount=0 should parse all rows")
+}


### PR DESCRIPTION
Fixes `ParsingStrategy.RowsCount` having no effect when parsing sheet-style content.

**Problem**

In `parseByRowIterator`:

```go
if ps.RowsCount != 0 && len(docs) == ps.RowsCount {
    break
}
```

`docs` is only populated **after** the row loop finishes (the per-row documents are appended at the end of the function), so `len(docs)` is always `0` inside the loop and the break never fires. As a result `RowsCount` was silently ignored — e.g. `domain/knowledge/service/sheet.go` sets `RowsCount: 5` to parse only a few rows for type assertion, but the whole sheet was parsed instead.

**Fix**

Check the count of accumulated data rows (`len(expData)`), which grows inside the loop, using `>=` for robustness:

```go
if ps.RowsCount != 0 && len(expData) >= ps.RowsCount {
    break
}
```

**Tests**

`parse_iter_test.go` adds:
- `TestParseByRowIteratorRowsCount`: `RowsCount=3` caps the output to 3 rows (fails on old code — returns all rows).
- `TestParseByRowIteratorAllRows`: `RowsCount=0` means no limit.

```
go test ./infra/document/parser/impl/builtin/ -run TestParseByRowIterator
```