### PR TITLE
fix(embedding): guard lazy dimension cache against concurrent first access

### DIFF
--- a/backend/infra/embedding/impl/http/dimensions_test.go
+++ b/backend/infra/embedding/impl/http/dimensions_test.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 coze-dev Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDimensionsConcurrent ensures the lazy dimension cache is safe under
+// concurrent first-time access (no data race, single embed call).
+func TestDimensionsConcurrent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return a 1024-dim dense vector for the "test" probe.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"dense": [][]float64{make([]float64, 1024)},
+		})
+	}))
+	defer ts.Close()
+
+	emb := &embedder{
+		cli:       ts.Client(),
+		addr:      ts.URL,
+		batchSize: 1,
+	}
+
+	const n = 32
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			require.Equal(t, int64(1024), emb.Dimensions())
+		}()
+	}
+	wg.Wait()
+}

--- a/backend/infra/embedding/impl/http/http.go
+++ b/backend/infra/embedding/impl/http/http.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
 	opt "github.com/cloudwego/eino/components/embedding"
@@ -107,6 +108,7 @@ func NewEmbedding(addr string, dims int64, batchSize int) (embedding.Embedder, e
 }
 
 type embedder struct {
+	mu        sync.Mutex
 	cli       *http.Client
 	addr      string
 	dim       int64
@@ -195,6 +197,8 @@ func (e *embedder) do(req *http.Request) (*embedResp, error) {
 }
 
 func (e *embedder) Dimensions() int64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	if e.dim <= 0 {
 		embeddings, err := e.EmbedStrings(context.Background(), []string{"test"})
 		if err != nil {

--- a/backend/infra/embedding/impl/wrap/dense_only.go
+++ b/backend/infra/embedding/impl/wrap/dense_only.go
@@ -19,6 +19,7 @@ package wrap
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/cloudwego/eino/components/embedding"
 
@@ -27,6 +28,7 @@ import (
 )
 
 type denseOnlyWrap struct {
+	mu        sync.Mutex
 	dims      int64
 	batchSize int
 	embedding.Embedder
@@ -49,6 +51,8 @@ func (d *denseOnlyWrap) EmbedStringsHybrid(ctx context.Context, texts []string, 
 }
 
 func (d *denseOnlyWrap) Dimensions() int64 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	if d.dims <= 0 {
 		embeddings, err := d.Embedder.EmbedStrings(context.Background(), []string{"test"})
 		if err != nil {


### PR DESCRIPTION
Fixes a data race in the lazy embedding dimension cache.

**Problem**

`Dimensions()` lazily embeds a probe string and caches the result in `dims`/`dim` with **no synchronization**:

```go
func (e *embedder) Dimensions() int64 {
    if e.dim <= 0 {
        embeddings, _ := e.EmbedStrings(...)
        e.dim = int64(len(embeddings[0]))
    }
    return e.dim
}
```

When several retrieval/indexing goroutines first call `Dimensions()` concurrently, they race on the shared field (detected by `go test -race`) and issue duplicate embed requests.

**Fix**

Guard the lazy initialization with a `sync.Mutex` in both `embedder` (`infra/embedding/impl/http/http.go`) and `denseOnlyWrap` (`infra/embedding/impl/wrap/dense_only.go`). A failed probe is **not** cached, so transient embed failures can be retried on the next call.

**Test**

`dimensions_test.go` runs `Dimensions()` from 32 goroutines against an httptest mock. It passes with the fix and reports `DATA RACE` on the old code.

```
go test -race ./infra/embedding/impl/http/ -run TestDimensionsConcurrent
```