### PR TITLE
fix(modelmgr): return error instead of panicking when old model has no conn_config

### DIFF
--- a/backend/bizpkg/config/modelmgr/deprecate_model_get.go
+++ b/backend/bizpkg/config/modelmgr/deprecate_model_get.go
@@ -247,6 +247,9 @@ func (c *ModelConfig) SetDoNotUseOldModelConf(ctx context.Context) error {
 
 func toNewModel(old *OldModel) (*Model, error) {
 	// to new model, old: {"ID":68010,"Name":"Test_Ollama_Qwen2.5vl-7b","Description":{"zh":"ollama 模型简介","en":"ollama model description"},"Meta":{"Protocol":"ollama","ConnConfig":null}}
+	if old.Meta.ConnConfig == nil {
+		return nil, fmt.Errorf("old model %s has no conn_config, unable to convert to new model config", old.Name)
+	}
 	modelClass := strProtocolToModelClass(old.Meta.Protocol)
 	provider, _ := GetModelProvider(modelClass)
 

--- a/backend/bizpkg/config/modelmgr/deprecate_model_get_test.go
+++ b/backend/bizpkg/config/modelmgr/deprecate_model_get_test.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 coze-dev Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package modelmgr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToNewModelNilConnConfig(t *testing.T) {
+	old := &OldModel{
+		ID:   1,
+		Name: "model-without-conn-config",
+		Meta: ModelOldMeta{
+			Protocol: ProtocolOllama,
+			// ConnConfig is nil — e.g. a yaml that omits meta.conn_config.
+		},
+	}
+
+	// Must return a clear error instead of panicking on a nil dereference.
+	m, err := toNewModel(old)
+	require.Error(t, err)
+	require.Nil(t, m)
+	require.Contains(t, err.Error(), "conn_config")
+}


### PR DESCRIPTION
Fixes a nil pointer dereference during model config load.

**Problem**

`toNewModel` dereferenced `old.Meta.ConnConfig` unconditionally. `ConnConfig` is a pointer (`*OldConfig`) and the docstring example even shows `"ConnConfig":null`. A model yaml that omits `meta.conn_config` causes a nil pointer dereference panic while loading model configs (`initModelByTemplate` -> `toNewModel`), crashing server startup.

**Fix**

Return a clear error when `old.Meta.ConnConfig` is nil.

**Test**

`TestToNewModelNilConnConfig` passes with the guard and panics (nil pointer dereference) without it.

```
go test ./bizpkg/config/modelmgr/ -run TestToNewModelNilConnConfig
```