### PR TITLE
fix(workflow): dereference loop output Ref only after nil check

### DIFF
--- a/backend/domain/workflow/internal/nodes/loop/loop.go
+++ b/backend/domain/workflow/internal/nodes/loop/loop.go
@@ -176,10 +176,10 @@ func (c *Config) Build(_ context.Context, ns *schema.NodeSchema, opts ...schema.
 		}
 
 		k := info.Path[0]
-		fromPath := info.Source.Ref.FromPath
 
 		if info.Source.Ref != nil && info.Source.Ref.VariableType != nil &&
 			*info.Source.Ref.VariableType == vo.ParentIntermediate {
+			fromPath := info.Source.Ref.FromPath
 			if len(fromPath) > 1 {
 				return nil, fmt.Errorf("loop output refers to intermediate variable, but path length > 1: %v", fromPath)
 			}

--- a/backend/domain/workflow/internal/nodes/loop/loop_test.go
+++ b/backend/domain/workflow/internal/nodes/loop/loop_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 coze-dev Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loop
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudwego/eino/compose"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coze-dev/coze-studio/backend/domain/workflow/entity/vo"
+	"github.com/coze-dev/coze-studio/backend/domain/workflow/internal/schema"
+)
+
+type mockInner struct {
+	compose.Runnable[map[string]any, map[string]any]
+}
+
+// An output source with a literal value has Ref == nil; Build must not panic.
+func TestBuildLiteralOutputSource(t *testing.T) {
+	c := &Config{}
+	ns := &schema.NodeSchema{
+		Key: "loop_1",
+		OutputSources: []*vo.FieldInfo{
+			{
+				Path: []string{"output"},
+				Source: vo.FieldSource{
+					Val: "literal",
+				},
+			},
+		},
+	}
+
+	node, err := c.Build(context.Background(), ns, schema.WithInnerWorkflow(&mockInner{}))
+	require.NoError(t, err)
+	require.NotNil(t, node)
+}


### PR DESCRIPTION
Fixes a nil pointer dereference when building a Loop node.

**Problem**

`Config.Build` read `info.Source.Ref.FromPath` **before** checking `info.Source.Ref != nil`:

```go
fromPath := info.Source.Ref.FromPath   // dereferenced unconditionally

if info.Source.Ref != nil && ...       // nil check came too late
```

An output source backed by a literal value has `Ref == nil` (the canvas converter produces `FieldSource{Val: ...}` for constants, see `canvas/convert/type_convert.go`), so building a Loop node with such an output panicked instead of returning a node.

**Fix**

Move the dereference inside the existing nil-guarded branch (fromPath is only used there).

**Test**

`TestBuildLiteralOutputSource` builds a loop node with a literal output source; it panics (nil pointer dereference) on the old code and succeeds with the fix.

```
go test ./domain/workflow/internal/nodes/loop/ -run TestBuildLiteralOutputSource
```