### PR TITLE
fix(knowledge): return recovered panic error from knowledge copy

### DIFF
--- a/backend/domain/knowledge/service/datacopy.go
+++ b/backend/domain/knowledge/service/datacopy.go
@@ -120,8 +120,7 @@ func (k *knowledgeSVC) CopyKnowledge(ctx context.Context, request *CopyKnowledge
 	return copyResp, nil
 }
 
-func (k *knowledgeSVC) copyDo(ctx context.Context, copyCtx *knowledgeCopyCtx) (*CopyKnowledgeResponse, error) {
-	var err error
+func (k *knowledgeSVC) copyDo(ctx context.Context, copyCtx *knowledgeCopyCtx) (copyResp *CopyKnowledgeResponse, err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			logs.CtxErrorf(ctx, "copy knowledge failed, err: %v", e)
@@ -144,9 +143,8 @@ func (k *knowledgeSVC) copyDo(ctx context.Context, copyCtx *knowledgeCopyCtx) (*
 				}
 			}
 			copyCtx.CopyTask.Status = copyEntity.DataCopyTaskStatusFail
-			err = crossdatacopy.DefaultSVC().UpdateCopyTask(ctx, &datacopy.UpdateCopyTaskReq{Task: copyCtx.CopyTask})
-			if err != nil {
-				logs.CtxErrorf(ctx, "update copy task failed, err: %v", err)
+			if upErr := crossdatacopy.DefaultSVC().UpdateCopyTask(ctx, &datacopy.UpdateCopyTaskReq{Task: copyCtx.CopyTask}); upErr != nil {
+				logs.CtxErrorf(ctx, "update copy task failed, err: %v", upErr)
 			}
 		}
 	}()

--- a/backend/domain/knowledge/service/datacopy_test.go
+++ b/backend/domain/knowledge/service/datacopy_test.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 coze-dev Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"gorm.io/gorm"
+
+	crossdatacopy "github.com/coze-dev/coze-studio/backend/crossdomain/datacopy"
+	"github.com/coze-dev/coze-studio/backend/domain/datacopy"
+	copyEntity "github.com/coze-dev/coze-studio/backend/domain/datacopy/entity"
+	"github.com/coze-dev/coze-studio/backend/domain/knowledge/internal/dal/model"
+	"github.com/coze-dev/coze-studio/backend/domain/knowledge/repository"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDataCopySvc struct{}
+
+func (fakeDataCopySvc) CheckAndGenCopyTask(ctx context.Context, req *datacopy.CheckAndGenCopyTaskReq) (*datacopy.CheckAndGenCopyTaskResp, error) {
+	return nil, nil
+}
+
+func (fakeDataCopySvc) UpdateCopyTask(ctx context.Context, req *datacopy.UpdateCopyTaskReq) error {
+	return nil
+}
+
+func (fakeDataCopySvc) UpdateCopyTaskWithTX(ctx context.Context, req *datacopy.UpdateCopyTaskReq, tx *gorm.DB) error {
+	return nil
+}
+
+// panicRepo panics on Upsert; GetByID reports "not found" so the deferred
+// cleanup in copyDo exits early without touching other dependencies.
+type panicRepo struct {
+	repository.KnowledgeRepo
+}
+
+func (panicRepo) Upsert(ctx context.Context, knowledge *model.Knowledge) error {
+	panic("boom")
+}
+
+func (panicRepo) GetByID(ctx context.Context, id int64) (*model.Knowledge, error) {
+	return nil, nil
+}
+
+// copyDo recovers panics; the recovered error must be returned to the
+// caller instead of being swallowed into a (nil, nil) response.
+func TestCopyDoPanicReturnsError(t *testing.T) {
+	ctx := context.Background()
+	crossdatacopy.SetDefaultSVC(fakeDataCopySvc{})
+	defer crossdatacopy.SetDefaultSVC(nil)
+
+	k := &knowledgeSVC{knowledgeRepo: panicRepo{}}
+	copyCtx := &knowledgeCopyCtx{
+		OriginData: &model.Knowledge{ID: 1},
+		CopyTask:   &copyEntity.CopyDataTask{TargetDataID: 2},
+	}
+
+	resp, err := k.copyDo(ctx, copyCtx)
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "panic")
+}


### PR DESCRIPTION
Fixes a swallowed error in the knowledge-copy failure path.

**Problem**

`copyDo` used `defer` + `recover()` for cleanup, but its return values were **unnamed**:

```go
func (k *knowledgeSVC) copyDo(...) (*CopyKnowledgeResponse, error) {
    var err error
    defer func() {
        if e := recover(); e != nil {
            err = errorx.New(...)   // assigned to the local var, lost
        }
        ...
    }()
```

When a panic occurred mid-copy, the recovered error was assigned to the local `err` variable but the function still returned **`(nil, nil)`**. The caller (`CopyKnowledge`) passed that up, and the response was silently lost — upstream dereferenced the nil response and the copy failure never surfaced.

Two related issues fixed in the same handler:

1. The cleanup block overwrote `err` with the `UpdateCopyTask` result, replacing the root cause.
2. On the success path, if the final `UpdateCopyTask` (Status = Success) call failed, `err` was left non-nil, so the deferred cleanup **deleted the just-copied target knowledge** and marked the task failed — while the function still returned a `Success` response to the caller. With named returns the explicit `return ..., nil` clears `err`, so cleanup no longer runs on that path and the reported result is consistent.

**Fix**

Use named return values `(copyResp *CopyKnowledgeResponse, err error)` so the recovered error is actually returned, and log the `UpdateCopyTask` result via a separate `upErr` variable.

**Test**

`TestCopyDoPanicReturnsError` injects a panic via the knowledge repo; on the old code `copyDo` returns `(nil, nil)` ("An error is expected but got nil"), with the fix it returns the panic error.

```
go test ./domain/knowledge/service/ -run TestCopyDoPanicReturnsError
```