### PR TITLE
fix(knowledge): write indexing panic error into caller's named return

### DIFF
--- a/backend/domain/knowledge/service/event_handle.go
+++ b/backend/domain/knowledge/service/event_handle.go
@@ -219,11 +219,12 @@ func (k *knowledgeSVC) validateDocumentStatus(ctx context.Context, doc *entity.D
 // handleIndexingErrors manages errors and recovery during indexing
 func (k *knowledgeSVC) handleIndexingErrors(ctx context.Context, event *entity.Event, err *error) {
 	if e := recover(); e != nil {
-		err = ptr.Of(errorx.New(errno.ErrKnowledgeSystemCode,
-			errorx.KV("msg", fmt.Sprintf("panic: %v", e))))
-		logs.CtxErrorf(ctx, "[indexDocument] panic, err: %v", err)
+		idxErr := errorx.New(errno.ErrKnowledgeSystemCode,
+			errorx.KV("msg", fmt.Sprintf("panic: %v", e)))
+		*err = idxErr
+		logs.CtxErrorf(ctx, "[indexDocument] panic, err: %v", idxErr)
 		k.setDocumentStatus(ctx, event.Document.ID,
-			int32(entity.DocumentStatusFailed), ptr.From(err).Error())
+			int32(entity.DocumentStatusFailed), idxErr.Error())
 		return
 	}
 

--- a/backend/domain/knowledge/service/event_handle_err_test.go
+++ b/backend/domain/knowledge/service/event_handle_err_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 coze-dev Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	knowledgeModel "github.com/coze-dev/coze-studio/backend/crossdomain/knowledge/model"
+	"github.com/coze-dev/coze-studio/backend/domain/knowledge/entity"
+	"github.com/coze-dev/coze-studio/backend/domain/knowledge/repository"
+	"github.com/stretchr/testify/require"
+)
+
+type noopDocRepo struct {
+	repository.KnowledgeDocumentRepo
+}
+
+func (noopDocRepo) SetStatus(ctx context.Context, documentID int64, status int32, reason string) error {
+	return nil
+}
+
+// A panic during indexing must be written back into the caller's named
+// return error; the old code reassigned the local *error parameter, so
+// the caller's error stayed nil and the MQ message was never retried.
+func TestHandleIndexingErrorsPanicPropagates(t *testing.T) {
+	k := &knowledgeSVC{documentRepo: noopDocRepo{}}
+	event := &entity.Event{Document: &entity.Document{Info: knowledgeModel.Info{ID: 1}}}
+
+	var err error
+	func() {
+		defer k.handleIndexingErrors(context.Background(), event, &err)
+		panic("boom")
+	}()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "panic")
+}


### PR DESCRIPTION
Fixes lost error propagation on panic during document indexing.

**Problem**

`indexDocument` registers `defer k.handleIndexingErrors(ctx, event, &err)` with its named return error. But `handleIndexingErrors` assigned the recovered panic error to the **local pointer parameter** instead of writing through it:

```go
func (k *knowledgeSVC) handleIndexingErrors(..., err *error) {
    if e := recover(); e != nil {
        err = ptr.Of(errorx.New(...))   // reassigns the local *error, no effect on caller
```

The caller's `err` stayed `nil`, so the MQ message was **acked as successful and never retried** — only the document status was set to failed. The retry path for transient indexing panics was effectively dead.

**Fix**

Write through the pointer: `*err = errorx.New(...)`.

**Test**

`TestHandleIndexingErrorsPanicPropagates` defers `handleIndexingErrors` around a panic; on the old code the caller's error stays nil ("An error is expected but got nil"), with the fix the panic error propagates.

```
go test ./domain/knowledge/service/ -run TestHandleIndexingErrorsPanicPropagates
```