### PR TITLE
fix(knowledge): guard against missing document in UpdateDocument and ListSlice

### DIFF
--- a/backend/domain/knowledge/service/knowledge.go
+++ b/backend/domain/knowledge/service/knowledge.go
@@ -372,6 +372,9 @@ func (k *knowledgeSVC) UpdateDocument(ctx context.Context, request *UpdateDocume
 	if err != nil {
 		return errorx.New(errno.ErrKnowledgeDBCode, errorx.KV("msg", err.Error()))
 	}
+	if doc == nil || doc.ID == 0 {
+		return errorx.New(errno.ErrKnowledgeNotExistCode, errorx.KVf("msg", "document not found, doc_id: %d", request.DocumentID))
+	}
 	if request.DocumentName != nil {
 		doc.Name = *request.DocumentName
 	}
@@ -862,6 +865,9 @@ func (k *knowledgeSVC) ListSlice(ctx context.Context, request *ListSliceRequest)
 	if err != nil {
 		logs.CtxErrorf(ctx, "get document failed, err: %v", err)
 		return nil, errorx.New(errno.ErrKnowledgeDBCode, errorx.KV("msg", err.Error()))
+	}
+	if doc == nil {
+		return nil, errorx.New(errno.ErrKnowledgeNotExistCode, errorx.KVf("msg", "document not found, doc_id: %d", ptr.From(request.DocumentID)))
 	}
 	resp := ListSliceResponse{}
 	if doc.Status == int32(entity.DocumentStatusDeleted) {

--- a/backend/domain/knowledge/service/knowledge_notfound_test.go
+++ b/backend/domain/knowledge/service/knowledge_notfound_test.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 coze-dev Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coze-dev/coze-studio/backend/domain/knowledge/internal/dal/model"
+	"github.com/coze-dev/coze-studio/backend/domain/knowledge/repository"
+	"github.com/stretchr/testify/require"
+)
+
+// missingDocRepo mimics the DAO: a not-found record returns (nil, nil).
+type missingDocRepo struct {
+	repository.KnowledgeDocumentRepo
+}
+
+func (missingDocRepo) GetByID(ctx context.Context, id int64) (*model.KnowledgeDocument, error) {
+	return nil, nil
+}
+
+// UpdateDocument on a non-existent document must return a not-found error
+// instead of dereferencing the nil document.
+func TestUpdateDocumentNotFound(t *testing.T) {
+	k := &knowledgeSVC{documentRepo: missingDocRepo{}}
+
+	err := k.UpdateDocument(context.Background(), &UpdateDocumentRequest{DocumentID: 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "document not found")
+}
+
+// ListSlice on a non-existent document must return a not-found error
+// instead of dereferencing the nil document.
+func TestListSliceDocumentNotFound(t *testing.T) {
+	k := &knowledgeSVC{documentRepo: missingDocRepo{}}
+
+	docID := int64(1)
+	_, err := k.ListSlice(context.Background(), &ListSliceRequest{DocumentID: &docID})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "document not found")
+}


### PR DESCRIPTION
Fixes a nil pointer dereference when operating on a non-existent document.

**Problem**

The document DAO's `GetByID` returns `(nil, nil)` when the record does not exist (`gorm.ErrRecordNotFound` is swallowed). `UpdateDocument` dereferenced the returned document with no nil check:

```go
doc, err := k.documentRepo.GetByID(ctx, request.DocumentID)
...
doc.Name = *request.DocumentName   // panics when doc == nil
```

Updating or listing slices of a non-existent / already-deleted document panicked the request instead of returning a not-found error. `DeleteDocument` in the same file already guards with `if doc == nil || doc.ID == 0` — `UpdateDocument` just missed it.

**Fix**

- `UpdateDocument`: return `ErrKnowledgeNotExistCode` when the document is missing (an update on a missing document should fail, unlike an idempotent delete).
- `ListSlice`: same missing guard (`doc.Status` was dereferenced unchecked).

**Test**

`TestUpdateDocumentNotFound` / `TestListSliceDocumentNotFound` use a repo returning `(nil, nil)`; they panic (nil pointer dereference) on the old code and return not-found errors with the fix.

```
go test ./domain/knowledge/service/ -run 'TestUpdateDocumentNotFound|TestListSliceDocumentNotFound'
```