### PR TITLE
fix(plugin): block SSRF to private and metadata hosts in tool HTTP calls

### DIFF
--- a/backend/domain/plugin/service/tool/invocation_http.go
+++ b/backend/domain/plugin/service/tool/invocation_http.go
@@ -19,11 +19,14 @@ package tool
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/cloudwego/eino/compose"
@@ -48,7 +51,23 @@ type httpCallImpl struct {
 	ConversationID int64
 }
 
-var defaultHttpCli *resty.Client = resty.New()
+var defaultHttpCli *resty.Client = newToolHTTPClient()
+
+var (
+	errToolRequestHostNotAllowed = errors.New("request host is not allowed")
+	errToolRequestUnsupportedURL = errors.New("unsupported url scheme")
+	errToolRequestEmptyHost      = errors.New("request host is empty")
+
+	toolRequestDialer = &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+
+	cgnatCIDR = net.IPNet{
+		IP:   net.IPv4(100, 64, 0, 0),
+		Mask: net.CIDRMask(10, 32),
+	}
+)
 
 func NewHttpCallImpl(ConversationID int64) Invocation {
 	return &httpCallImpl{
@@ -251,6 +270,10 @@ func (h *httpCallImpl) buildHTTPRequestURL(ctx context.Context, rawURL string, a
 		reqURL.RawQuery = encodeQuery
 	}
 
+	if err = validateToolRequestURL(reqURL); err != nil {
+		return nil, errorx.New(errno.ErrPluginExecuteToolFailed, errorx.KV(errno.PluginMsgKey, err.Error()))
+	}
+
 	return reqURL, nil
 }
 
@@ -383,4 +406,129 @@ func (h *httpCallImpl) buildHTTPRequestHeader(ctx context.Context, args *Invocat
 	}
 
 	return header, nil
+}
+
+func newToolHTTPClient() *resty.Client {
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialToolRequest,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	cli := resty.New()
+	cli.SetTransport(transport)
+	cli.GetClient().CheckRedirect = checkToolRequestRedirect
+	return cli
+}
+
+func checkToolRequestRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	return validateToolRequestURL(req.URL)
+}
+
+func validateToolRequestURL(u *url.URL) error {
+	if u == nil {
+		return errToolRequestEmptyHost
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return errToolRequestUnsupportedURL
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return errToolRequestEmptyHost
+	}
+
+	ips, err := resolveToolRequestHost(host)
+	if err != nil {
+		return fmt.Errorf("resolve request host failed, err=%s", err)
+	}
+	for _, ip := range ips {
+		if isForbiddenToolRequestIP(ip) {
+			return errToolRequestHostNotAllowed
+		}
+	}
+
+	return nil
+}
+
+func resolveToolRequestHost(host string) ([]net.IP, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return []net.IP{ip}, nil
+	}
+
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return nil, err
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no addresses for host")
+	}
+	return ips, nil
+}
+
+func isForbiddenToolRequestIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		ip = ip4
+	}
+
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() {
+		return true
+	}
+
+	if ip4 := ip.To4(); ip4 != nil {
+		if ip4[0] == 0 {
+			return true
+		}
+		if cgnatCIDR.Contains(ip4) {
+			return true
+		}
+		if ip4.Equal(net.IPv4bcast) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func dialToolRequest(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	ips, err := resolveToolRequestHost(host)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	tried := false
+	for _, ip := range ips {
+		if isForbiddenToolRequestIP(ip) {
+			lastErr = errToolRequestHostNotAllowed
+			continue
+		}
+		tried = true
+		conn, dialErr := toolRequestDialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		if dialErr == nil {
+			return conn, nil
+		}
+		lastErr = dialErr
+	}
+	if !tried && lastErr == nil {
+		lastErr = errToolRequestHostNotAllowed
+	}
+	return nil, lastErr
 }

--- a/backend/domain/plugin/service/tool/invocation_http_test.go
+++ b/backend/domain/plugin/service/tool/invocation_http_test.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025 coze-dev Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tool
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coze-dev/coze-studio/backend/crossdomain/plugin/model"
+	"github.com/coze-dev/coze-studio/backend/domain/plugin/entity"
+	"github.com/coze-dev/coze-studio/backend/pkg/lang/ptr"
+)
+
+func testHTTPInvocationArgs(serverURL string) *InvocationArgs {
+	return &InvocationArgs{
+		ServerURL: serverURL,
+		Tool: &entity.ToolInfo{
+			Method: ptr.Of("GET"),
+			SubURL: ptr.Of("/"),
+			Operation: &model.Openapi3Operation{
+				Operation: &openapi3.Operation{},
+			},
+		},
+	}
+}
+
+func TestBuildHTTPRequestRejectsInternalHosts(t *testing.T) {
+	h := &httpCallImpl{}
+	ctx := context.Background()
+
+	cases := []struct {
+		name      string
+		serverURL string
+	}{
+		{name: "ipv4 loopback", serverURL: "http://127.0.0.1"},
+		{name: "ipv4 loopback with port", serverURL: "http://127.0.0.1:8080"},
+		{name: "ipv6 loopback", serverURL: "http://[::1]"},
+		{name: "localhost", serverURL: "http://localhost"},
+		{name: "rfc1918 10/8", serverURL: "http://10.0.0.1"},
+		{name: "rfc1918 192.168/16", serverURL: "http://192.168.1.1"},
+		{name: "rfc1918 172.16/12", serverURL: "http://172.16.0.1"},
+		{name: "link-local metadata", serverURL: "http://169.254.169.254"},
+		{name: "unspecified ipv4", serverURL: "http://0.0.0.0"},
+		{name: "cgnat 100.64/10", serverURL: "http://100.64.0.1"},
+		{name: "ipv4-mapped loopback", serverURL: "http://[::ffff:127.0.0.1]"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := h.buildHTTPRequest(ctx, testHTTPInvocationArgs(tc.serverURL))
+			assert.Error(t, err, "expected internal host %s to be rejected", tc.serverURL)
+		})
+	}
+}
+
+func TestBuildHTTPRequestRejectsNonHTTPSchemes(t *testing.T) {
+	h := &httpCallImpl{}
+	ctx := context.Background()
+
+	cases := []string{
+		"file://tmp/x",
+		"gopher://192.0.2.1",
+		"ftp://192.0.2.1",
+		"dict://192.0.2.1",
+	}
+
+	for _, serverURL := range cases {
+		t.Run(serverURL, func(t *testing.T) {
+			_, err := h.buildHTTPRequest(ctx, testHTTPInvocationArgs(serverURL))
+			assert.Error(t, err, "expected scheme on %s to be rejected", serverURL)
+		})
+	}
+}
+
+func TestBuildHTTPRequestAllowsPublicHTTPHosts(t *testing.T) {
+	h := &httpCallImpl{}
+	ctx := context.Background()
+
+	cases := []string{
+		"http://192.0.2.1",
+		"https://192.0.2.1",
+		"http://192.0.2.1:443",
+	}
+
+	for _, serverURL := range cases {
+		t.Run(serverURL, func(t *testing.T) {
+			req, err := h.buildHTTPRequest(ctx, testHTTPInvocationArgs(serverURL))
+			require.NoError(t, err)
+			require.NotNil(t, req)
+			assert.Equal(t, "192.0.2.1", req.URL.Hostname())
+		})
+	}
+}
+
+func TestDialToolRequestRejectsInternalAddr(t *testing.T) {
+	ctx := context.Background()
+	addrs := []string{
+		"127.0.0.1:1",
+		"[::1]:1",
+		"10.0.0.1:80",
+		"169.254.169.254:80",
+		"192.168.0.1:443",
+	}
+	for _, addr := range addrs {
+		t.Run(addr, func(t *testing.T) {
+			conn, err := dialToolRequest(ctx, "tcp", addr)
+			if conn != nil {
+				_ = conn.Close()
+			}
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, errToolRequestHostNotAllowed)
+		})
+	}
+}
+
+func TestCheckToolRequestRedirectRejectsInternalHost(t *testing.T) {
+	via, err := http.NewRequest(http.MethodGet, "http://192.0.2.1/", nil)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/", nil)
+	require.NoError(t, err)
+
+	assert.Error(t, checkToolRequestRedirect(req, []*http.Request{via}))
+}
+
+func TestIsForbiddenToolRequestIP(t *testing.T) {
+	assert.True(t, isForbiddenToolRequestIP(net.ParseIP("127.0.0.1")))
+	assert.True(t, isForbiddenToolRequestIP(net.ParseIP("::1")))
+	assert.True(t, isForbiddenToolRequestIP(net.ParseIP("10.1.2.3")))
+	assert.True(t, isForbiddenToolRequestIP(net.ParseIP("169.254.169.254")))
+	assert.True(t, isForbiddenToolRequestIP(net.ParseIP("100.64.0.1")))
+	assert.True(t, isForbiddenToolRequestIP(net.ParseIP("::ffff:127.0.0.1")))
+	assert.True(t, isForbiddenToolRequestIP(net.ParseIP("fc00::1")))
+	assert.False(t, isForbiddenToolRequestIP(net.ParseIP("192.0.2.1")))
+	assert.False(t, isForbiddenToolRequestIP(net.ParseIP("8.8.8.8")))
+}


### PR DESCRIPTION
## Summary
Plugin tool HTTP invocation built requests from attacker-controlled server/path values with no scheme check and no private/metadata IP blocking, so any authenticated user could reach internal-only hosts (loopback, RFC1918, link-local metadata, CGNAT) and non-HTTP schemes via tool execution / Test Run.

This change:
- Allows only `http`/`https`
- Rejects loopback, private, link-local, unspecified, multicast, and CGNAT (`100.64.0.0/10`) addresses (including IPv4-mapped forms)
- Re-validates the resolved IP at dial time (DNS rebinding)
- Re-validates redirect targets

Fixes #2711

## Test plan
- [x] `cd backend && go test ./domain/plugin/service/tool/ -count=1`
- [x] Unit coverage for loopback / RFC1918 / link-local metadata / CGNAT / non-HTTP schemes / public TEST-NET allow / dial-time reject