### PR TITLE
fix(docs): replace {project_name} placeholders in CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Version:**
 
-Please provide the version of {project_name} you are using.
+Please provide the version of coze-studio you are using.
 
 **Environment:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We use [git-flow](https://nvie.com/posts/a-successful-git-branching-model/) as o
 
 ## Bugs
 ### 1. How to Find Known Issues
-We are using [Github Issues](https://github.com/coze-dev/{project_name}/issues) for our public bugs. We keep a close eye on this and try to make it clear when we have an internal fix in progress. Before filing a new task, try to make sure your problem doesn’t already exist.
+We are using [Github Issues](https://github.com/coze-dev/coze-studio/issues) for our public bugs. We keep a close eye on this and try to make it clear when we have an internal fix in progress. Before filing a new task, try to make sure your problem doesn’t already exist.
 
 ### 2. Reporting New Issues
 Providing a reduced test code is a recommended way for reporting issues. Then can place in:
@@ -23,9 +23,9 @@ Please do not report the safe disclosure of bugs to public issues. Contact us by
 
 ## Submit a Pull Request
 Before you submit your Pull Request (PR) consider the following guidelines:
-1. Search [GitHub](https://github.com/coze-dev/{project_name}/pulls) for an open or closed PR that relates to your submission. You don't want to duplicate existing efforts.
+1. Search [GitHub](https://github.com/coze-dev/coze-studio/pulls) for an open or closed PR that relates to your submission. You don't want to duplicate existing efforts.
 2. Be sure that an issue describes the problem you're fixing, or documents the design for the feature you'd like to add. Discussing the design upfront helps to ensure that we're ready to accept your work.
-3. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the coze-dev {project_name} repo.
+3. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the coze-dev/coze-studio repo.
 4. In your forked repository, make your changes in a new git branch:
     ```
     git checkout -b my-fix-branch main
@@ -38,7 +38,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     ```
     git push origin my-fix-branch
     ```
-9. In GitHub, send a pull request to `{project_name}:main`
+9. In GitHub, send a pull request to `coze-studio:main`
 
 ## Contribution Prerequisites
 - Our development environment keeps up with [Go Official](https://golang.org/project/).


### PR DESCRIPTION
## Summary
- Replace four unreplaced `{project_name}` placeholders in `CONTRIBUTING.md` with `coze-studio`.
- Fixes broken Issues / Pull Requests links that previously pointed at `coze-dev/{project_name}` (404).
- Clarifies fork target and PR destination (`coze-studio:main`).

Fixes #2737

## Test plan
- [x] Search `CONTRIBUTING.md` for `{project_name}` — zero matches
- [x] Open linked Issues / PRs URLs — resolve to `coze-dev/coze-studio`