### PR TITLE
fix(knowledge): guard nil strategies when parsing documents

### DIFF
--- a/backend/domain/knowledge/internal/convert/parser.go
+++ b/backend/domain/knowledge/internal/convert/parser.go
@@ -62,6 +62,15 @@ func ToParseConfig(fileExtension parser.FileExtension, ps *entity.ParsingStrateg
 			MaxDepth:        cs.MaxDepth,
 			SaveTitle:       cs.SaveTitle,
 		}
+	} else {
+		c = &parser.ChunkingStrategy{
+			ChunkType:       parser.ChunkTypeDefault,
+			ChunkSize:       consts.DefaultChunkSize,
+			Separator:       consts.DefaultSeparator,
+			Overlap:         consts.DefaultOverlap,
+			TrimSpace:       consts.DefaultTrimSpace,
+			TrimURLAndEmail: consts.DefaultTrimURLAndEmail,
+		}
 	}
 
 	return &parser.Config{

--- a/backend/domain/knowledge/internal/convert/parser_test.go
+++ b/backend/domain/knowledge/internal/convert/parser_test.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 coze-dev Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package convert
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coze-dev/coze-studio/backend/domain/knowledge/entity"
+	"github.com/coze-dev/coze-studio/backend/domain/knowledge/internal/consts"
+	"github.com/coze-dev/coze-studio/backend/infra/document/parser"
+)
+
+func TestToParseConfig_DefaultsChunkingStrategyWhenNil(t *testing.T) {
+	config := ToParseConfig(parser.FileExtensionMarkdown, nil, nil, false, nil)
+
+	require.NotNil(t, config)
+	require.NotNil(t, config.ChunkingStrategy)
+	assert.Equal(t, parser.ChunkTypeDefault, config.ChunkingStrategy.ChunkType)
+	assert.Equal(t, int64(consts.DefaultChunkSize), config.ChunkingStrategy.ChunkSize)
+	assert.Equal(t, consts.DefaultSeparator, config.ChunkingStrategy.Separator)
+	assert.Equal(t, int64(consts.DefaultOverlap), config.ChunkingStrategy.Overlap)
+	assert.Equal(t, consts.DefaultTrimSpace, config.ChunkingStrategy.TrimSpace)
+	assert.Equal(t, consts.DefaultTrimURLAndEmail, config.ChunkingStrategy.TrimURLAndEmail)
+	assert.Equal(t, int64(0), config.ChunkingStrategy.MaxDepth)
+	assert.False(t, config.ChunkingStrategy.SaveTitle)
+}
+
+func TestToParseConfig_PassesThroughChunkingStrategy(t *testing.T) {
+	chunkingStrategy := &entity.ChunkingStrategy{
+		ChunkType:       parser.ChunkTypeCustom,
+		ChunkSize:       1024,
+		Separator:       "---",
+		Overlap:         128,
+		TrimSpace:       true,
+		TrimURLAndEmail: true,
+		MaxDepth:        3,
+		SaveTitle:       true,
+	}
+
+	config := ToParseConfig(parser.FileExtensionMarkdown, nil, chunkingStrategy, false, nil)
+
+	require.NotNil(t, config)
+	require.NotNil(t, config.ChunkingStrategy)
+	assert.Equal(t, chunkingStrategy.ChunkType, config.ChunkingStrategy.ChunkType)
+	assert.Equal(t, chunkingStrategy.ChunkSize, config.ChunkingStrategy.ChunkSize)
+	assert.Equal(t, chunkingStrategy.Separator, config.ChunkingStrategy.Separator)
+	assert.Equal(t, chunkingStrategy.Overlap, config.ChunkingStrategy.Overlap)
+	assert.Equal(t, chunkingStrategy.TrimSpace, config.ChunkingStrategy.TrimSpace)
+	assert.Equal(t, chunkingStrategy.TrimURLAndEmail, config.ChunkingStrategy.TrimURLAndEmail)
+	assert.Equal(t, chunkingStrategy.MaxDepth, config.ChunkingStrategy.MaxDepth)
+	assert.Equal(t, chunkingStrategy.SaveTitle, config.ChunkingStrategy.SaveTitle)
+}

--- a/backend/infra/document/parser/impl/builtin/parse_markdown.go
+++ b/backend/infra/document/parser/impl/builtin/parse_markdown.go
@@ -48,8 +48,23 @@ func ParseMarkdown(config *contract.Config, storage storage.Storage, ocr ocr.OCR
 		}
 
 		node := mdParser.Parse(text.NewReader(b))
+		if config == nil {
+			return nil, fmt.Errorf("[ParseMarkdown] config is nil")
+		}
 		cs := config.ChunkingStrategy
 		ps := config.ParsingStrategy
+		if cs == nil {
+			// 防御性兜底：与 convert.ToParseConfig 的默认值保持一致，避免 nil 解引用 panic。
+			cs = &contract.ChunkingStrategy{
+				ChunkType: contract.ChunkTypeDefault,
+				ChunkSize: 800,
+				Separator: "\n",
+				Overlap:   10,
+			}
+		}
+		if ps == nil {
+			ps = &contract.ParsingStrategy{}
+		}
 
 		if cs.ChunkType != contract.ChunkTypeCustom && cs.ChunkType != contract.ChunkTypeDefault {
 			return nil, fmt.Errorf("[ParseMarkdown] chunk type not support, chunk type=%d", cs.ChunkType)

--- a/backend/infra/document/parser/impl/builtin/parse_markdown_test.go
+++ b/backend/infra/document/parser/impl/builtin/parse_markdown_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/cloudwego/eino/components/document/parser"
@@ -72,4 +73,23 @@ func assertDoc(t *testing.T, doc *schema.Document) {
 	assert.NotNil(t, doc.MetaData)
 	assert.Equal(t, int64(123), doc.MetaData["document_id"].(int64))
 	assert.Equal(t, int64(456), doc.MetaData["knowledge_id"].(int64))
+}
+
+func TestParseMarkdown_NilConfig(t *testing.T) {
+	ctx := context.Background()
+	pfn := ParseMarkdown(nil, nil, nil)
+	_, err := pfn(ctx, strings.NewReader("hello"))
+	assert.Error(t, err)
+}
+
+func TestParseMarkdown_NilStrategies(t *testing.T) {
+	ctx := context.Background()
+	// 防御性兜底：ChunkingStrategy/ParsingStrategy 为 nil 时不应 panic，应正常产出切片。
+	pfn := ParseMarkdown(&contract.Config{
+		FileExtension: contract.FileExtensionMarkdown,
+	}, nil, nil)
+	docs, err := pfn(ctx, strings.NewReader("hello world\nsecond line 星璇大桥"))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, docs)
+	assert.NotZero(t, docs[0].Content)
 }


### PR DESCRIPTION
## Problem

Creating a knowledge document without an explicit chunk strategy crashes the markdown parsing path with a nil pointer dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference
.../infra/document/parser/impl/builtin/parse_markdown.go:54  (*manager).GetParser.ParseMarkdown.func3
```

The document then ends up `status=9` (failed). Root cause: `ToParseConfig` leaves `parser.ChunkingStrategy` nil when `entity.ChunkingStrategy` is nil, and `ParseMarkdown` dereferences `cs.ChunkType` unconditionally.

## Fix

- `ToParseConfig`: default to a non-nil `ChunkingStrategy` (`ChunkTypeDefault` + existing consts defaults) when the input strategy is nil.
- `ParseMarkdown`: defensively default a nil `config`, `ChunkingStrategy`, and `ParsingStrategy` instead of panicking.

## Tests

- `TestToParseConfig_DefaultsChunkingStrategyWhenNil`
- `TestToParseConfig_PassesThroughChunkingStrategy`
- `TestParseMarkdown_NilConfig`
- `TestParseMarkdown_NilStrategies`

Verified: `go build ./...` and the affected packages pass (`go test -gcflags="all=-N -l" ./domain/knowledge/internal/convert/ ./infra/document/parser/impl/builtin/`).

Minimal, backwards-compatible change; no behavior change when a chunk strategy is explicitly provided.